### PR TITLE
feat: Implement DRY constants for TurboSign API examples

### DIFF
--- a/docs/TurboSign/API Signatures.md
+++ b/docs/TurboSign/API Signatures.md
@@ -85,6 +85,38 @@ Don't want to read all the details? Here's what you need to know:
   label="Complete Workflow Implementation"
 />
 
+### Quick Coordinate Example
+
+If you prefer using exact coordinates instead of text anchors:
+
+```json
+// Step 3 payload using coordinates instead of templates
+[
+  {
+    "recipientId": "5f673f37-9912-4e72-85aa-8f3649760f6b",
+    "type": "signature",
+    "page": 1,
+    "x": 100,
+    "y": 200,
+    "width": 200,
+    "height": 80,
+    "pageWidth": 612,
+    "pageHeight": 792
+  },
+  {
+    "recipientId": "5f673f37-9912-4e72-85aa-8f3649760f6b",
+    "type": "date",
+    "page": 1,
+    "x": 350,
+    "y": 300,
+    "width": 150,
+    "height": 30,
+    "pageWidth": 612,
+    "pageHeight": 792
+  }
+]
+```
+
 Now that you've seen the whole thing, let's dive into the details...
 
 ## Prerequisites
@@ -408,7 +440,14 @@ x-device-fingerprint: 280624a233f1fd39ce050a9e9d0a4cc9
 }
 ```
 
-### Template Configuration
+### Field Positioning Options
+
+TurboSign supports two field positioning methods:
+
+1. **Template-based positioning** (recommended) - Uses text anchors in your PDF
+2. **Coordinate-based positioning** - Uses exact pixel coordinates
+
+#### Template-based Field Configuration
 
 | Field                    | Type    | Required | Description                                            |
 | ------------------------ | ------- | -------- | ------------------------------------------------------ |
@@ -422,6 +461,61 @@ x-device-fingerprint: 280624a233f1fd39ce050a9e9d0a4cc9
 | `template.useRegex`      | boolean | No       | Whether to treat anchor as regex pattern               |
 | `defaultValue`           | string  | No       | Pre-filled value for the field                         |
 | `required`               | boolean | No       | Whether field must be completed                        |
+
+#### Coordinate-based Field Configuration
+
+For precise positioning when text anchors aren't suitable, use coordinate-based fields:
+
+```json
+[
+  {
+    "recipientId": "5f673f37-9912-4e72-85aa-8f3649760f6b",
+    "type": "signature",
+    "page": 1,
+    "x": 100,
+    "y": 200,
+    "width": 200,
+    "height": 80,
+    "pageWidth": 612,
+    "pageHeight": 792
+  },
+  {
+    "recipientId": "5f673f37-9912-4e72-85aa-8f3649760f6b",
+    "type": "date",
+    "page": 1,
+    "x": 350,
+    "y": 200,
+    "width": 150,
+    "height": 30,
+    "pageWidth": 612,
+    "pageHeight": 792
+  }
+]
+```
+
+| Field        | Type   | Required | Description                                     |
+| ------------ | ------ | -------- | ----------------------------------------------- |
+| `recipientId`| string | Yes      | Recipient ID from Step 2                       |
+| `type`       | string | Yes      | Field type - see Available Field Types section |
+| `page`       | number | Yes      | Page number (starts at 1)                      |
+| `x`          | number | Yes      | Horizontal position from left edge (pixels)    |
+| `y`          | number | Yes      | Vertical position from top edge (pixels)       |
+| `width`      | number | Yes      | Field width in pixels                           |
+| `height`     | number | Yes      | Field height in pixels                          |
+| `pageWidth`  | number | Yes      | Total page width in pixels                      |
+| `pageHeight` | number | Yes      | Total page height in pixels                     |
+
+**Coordinate System Notes:**
+- Origin (0,0) is at the top-left corner of the page
+- Standard US Letter page size is 612 x 792 pixels (8.5" x 11" at 72 DPI)
+- Fields cannot extend beyond page boundaries: `x + width ≤ pageWidth` and `y + height ≤ pageHeight`
+- All coordinate values must be non-negative numbers
+
+**When to use coordinate-based positioning:**
+- Precise pixel-perfect placement needed
+- PDF doesn't contain suitable text anchors
+- Programmatically generated field positions
+- Converting from existing coordinate-based systems
 
 <!-- ![Step 3: Prepare for Signing Postman Example](/img/turbosign/step3-prepare-postman.png) -->
 
@@ -462,6 +556,15 @@ x-device-fingerprint: 280624a233f1fd39ce050a9e9d0a4cc9
 - **Consistent naming**: Use consistent anchor naming conventions across documents
 - **Test coordinates**: Verify field positions with test documents before production
 - **Document validation**: Ensure PDFs are not password-protected or corrupted
+
+### Coordinate-based Positioning Tips
+
+- **Measure accurately**: Use PDF viewers with coordinate display to find exact positions
+- **Account for margins**: Consider document margins when calculating field positions
+- **Test on different devices**: Verify coordinates work across different PDF viewers
+- **Use standard page sizes**: Stick to common page dimensions (612x792 for US Letter)
+- **Validate boundaries**: Ensure fields don't extend beyond page edges
+- **Consider scaling**: Be aware that different DPI settings may affect coordinates
 
 ## Error Handling & Troubleshooting
 
@@ -516,12 +619,18 @@ x-device-fingerprint: 280624a233f1fd39ce050a9e9d0a4cc9
 
 **Symptoms**: Signature fields appear in wrong locations
 
-**Solutions**:
-
+**Template-based Solutions**:
 - Verify anchor text exists in the PDF document
 - Check anchor text matches exactly (case-sensitive by default)
 - Test with `caseSensitive: false` if having matching issues
 - Use PDF coordinates as fallback if anchors don't work
+
+**Coordinate-based Solutions**:
+- Verify page dimensions match your PDF's actual size
+- Check that x,y coordinates are within page boundaries
+- Ensure coordinates account for any PDF margins or headers
+- Test with different page numbers if multi-page document
+- Validate that `x + width ≤ pageWidth` and `y + height ≤ pageHeight`
 
 #### Webhook Integration Issues
 

--- a/docs/TurboSign/API Signatures.md
+++ b/docs/TurboSign/API Signatures.md
@@ -149,8 +149,7 @@ Additional required headers for all requests:
 
 ```http
 x-rapiddocx-org-id: YOUR_ORGANIZATION_ID
-origin: https://www.turbodocx.com
-accept: application/json, text/plain, */*
+User-Agent: TurboDocx API Client
 ```
 
 ## Step 1: Upload Document
@@ -169,9 +168,7 @@ POST https://www.turbodocx.com/turbosign/documents/upload
 Content-Type: multipart/form-data
 Authorization: Bearer YOUR_API_TOKEN
 x-rapiddocx-org-id: YOUR_ORGANIZATION_ID
-origin: https://www.turbodocx.com
-referer: https://www.turbodocx.com
-accept: application/json, text/plain, */*
+User-Agent: TurboDocx API Client
 ```
 
 ### Request Body (Form Data)
@@ -235,12 +232,7 @@ POST https://www.turbodocx.com/turbosign/documents/{documentId}/update-with-reci
 Content-Type: application/json
 Authorization: Bearer YOUR_API_TOKEN
 x-rapiddocx-org-id: YOUR_ORGANIZATION_ID
-origin: https://www.turbodocx.com
-referer: https://www.turbodocx.com
-accept: application/json, text/plain, */*
-dnt: 1
-accept-language: en-US,en;q=0.9
-priority: u=1, i
+User-Agent: TurboDocx API Client
 ```
 
 ### Request Body
@@ -353,20 +345,7 @@ POST https://www.turbodocx.com/turbosign/documents/{documentId}/prepare-for-sign
 Content-Type: application/json
 Authorization: Bearer YOUR_API_TOKEN
 x-rapiddocx-org-id: YOUR_ORGANIZATION_ID
-origin: https://www.turbodocx.com
-referer: https://www.turbodocx.com
-accept: application/json, text/plain, */*
-dnt: 1
-accept-language: en-US,en;q=0.9
-priority: u=1, i
-sec-ch-ua: "Not)A;Brand";v="8", "Chromium";v="138", "Google Chrome";v="138"
-sec-ch-ua-mobile: ?0
-sec-ch-ua-platform: "Windows"
-sec-fetch-dest: empty
-sec-fetch-mode: cors
-sec-fetch-site: same-site
-user-agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/138.0.0.0 Safari/537.36
-x-device-fingerprint: 280624a233f1fd39ce050a9e9d0a4cc9
+User-Agent: TurboDocx API Client
 ```
 
 ### Request Body

--- a/static/scripts/turbosign/api/complete-workflow/csharp/controller.cs
+++ b/static/scripts/turbosign/api/complete-workflow/csharp/controller.cs
@@ -22,9 +22,7 @@ class Program
         
         client.DefaultRequestHeaders.Add("Authorization", "Bearer YOUR_API_TOKEN");
         client.DefaultRequestHeaders.Add("x-rapiddocx-org-id", "YOUR_ORGANIZATION_ID");
-        client.DefaultRequestHeaders.Add("origin", "https://www.turbodocx.com");
-        client.DefaultRequestHeaders.Add("referer", "https://www.turbodocx.com");
-        client.DefaultRequestHeaders.Add("accept", "application/json, text/plain, */*");
+        client.DefaultRequestHeaders.Add("User-Agent", "TurboDocx API Client");
         
         var uploadResponse = await client.PostAsync("https://www.turbodocx.com/turbosign/documents/upload", uploadContent);
         var uploadResult = await uploadResponse.Content.ReadAsStringAsync();

--- a/static/scripts/turbosign/api/complete-workflow/csharp/controller.cs
+++ b/static/scripts/turbosign/api/complete-workflow/csharp/controller.cs
@@ -10,7 +10,7 @@ class Program
     // Configuration - Update these values
     private const string API_TOKEN = "YOUR_API_TOKEN";
     private const string ORG_ID = "YOUR_ORGANIZATION_ID";
-    private const string BASE_URL = "https://www.turbodocx.com/turbosign";
+    private const string BASE_URL = "https://api.turbodocx.com";
     private const string DOCUMENT_NAME = "Contract Agreement";
     static async Task Main(string[] args)
     {

--- a/static/scripts/turbosign/api/complete-workflow/csharp/controller.cs
+++ b/static/scripts/turbosign/api/complete-workflow/csharp/controller.cs
@@ -7,6 +7,11 @@ using System.Text.Json;
 
 class Program
 {
+    // Configuration - Update these values
+    private const string API_TOKEN = "YOUR_API_TOKEN";
+    private const string ORG_ID = "YOUR_ORGANIZATION_ID";
+    private const string BASE_URL = "https://www.turbodocx.com/turbosign";
+    private const string DOCUMENT_NAME = "Contract Agreement";
     static async Task Main(string[] args)
     {
         // Complete Workflow: Upload → Recipients → Prepare
@@ -14,17 +19,17 @@ class Program
         
         // Step 1: Upload Document
         using var uploadContent = new MultipartFormDataContent();
-        uploadContent.Add(new StringContent("Contract Agreement"), "name");
+        uploadContent.Add(new StringContent(DOCUMENT_NAME), "name");
         
         var fileContent = new ByteArrayContent(File.ReadAllBytes("./document.pdf"));
         fileContent.Headers.ContentType = new System.Net.Http.Headers.MediaTypeHeaderValue("application/pdf");
         uploadContent.Add(fileContent, "file", "document.pdf");
         
-        client.DefaultRequestHeaders.Add("Authorization", "Bearer YOUR_API_TOKEN");
-        client.DefaultRequestHeaders.Add("x-rapiddocx-org-id", "YOUR_ORGANIZATION_ID");
+        client.DefaultRequestHeaders.Add("Authorization", "Bearer " + API_TOKEN);
+        client.DefaultRequestHeaders.Add("x-rapiddocx-org-id", ORG_ID);
         client.DefaultRequestHeaders.Add("User-Agent", "TurboDocx API Client");
         
-        var uploadResponse = await client.PostAsync("https://www.turbodocx.com/turbosign/documents/upload", uploadContent);
+        var uploadResponse = await client.PostAsync(BASE_URL + "/documents/upload", uploadContent);
         var uploadResult = await uploadResponse.Content.ReadAsStringAsync();
         
         var uploadDoc = JsonDocument.Parse(uploadResult);
@@ -33,7 +38,7 @@ class Program
         // Step 2: Add Recipients
         var recipientPayload = @"{
           ""document"": {
-            ""name"": ""Contract Agreement - Updated"",
+            ""name"": """ + DOCUMENT_NAME + " - Updated"",
             ""description"": ""This document requires electronic signatures from both parties. Please review all content carefully before signing.""
           },
           ""recipients"": [
@@ -61,7 +66,7 @@ class Program
         }";
         
         var recipientContent = new StringContent(recipientPayload, Encoding.UTF8, "application/json");
-        var recipientResponse = await client.PostAsync($"https://www.turbodocx.com/turbosign/documents/{documentId}/update-with-recipients", recipientContent);
+        var recipientResponse = await client.PostAsync($"{BASE_URL}/documents/{documentId}/update-with-recipients", recipientContent);
         var recipientResult = await recipientResponse.Content.ReadAsStringAsync();
         
         var recipientDoc = JsonDocument.Parse(recipientResult);
@@ -128,7 +133,7 @@ class Program
         ]";
         
         var prepareContent = new StringContent(signaturePayload, Encoding.UTF8, "application/json");
-        var prepareResponse = await client.PostAsync($"https://www.turbodocx.com/turbosign/documents/{documentId}/prepare-for-signing", prepareContent);
+        var prepareResponse = await client.PostAsync($"{BASE_URL}/documents/{documentId}/prepare-for-signing", prepareContent);
         var finalResult = await prepareResponse.Content.ReadAsStringAsync();
         
         Console.WriteLine(finalResult);

--- a/static/scripts/turbosign/api/complete-workflow/csharp/minimal.cs
+++ b/static/scripts/turbosign/api/complete-workflow/csharp/minimal.cs
@@ -22,9 +22,7 @@ class Program
         
         client.DefaultRequestHeaders.Add("Authorization", "Bearer YOUR_API_TOKEN");
         client.DefaultRequestHeaders.Add("x-rapiddocx-org-id", "YOUR_ORGANIZATION_ID");
-        client.DefaultRequestHeaders.Add("origin", "https://www.turbodocx.com");
-        client.DefaultRequestHeaders.Add("referer", "https://www.turbodocx.com");
-        client.DefaultRequestHeaders.Add("accept", "application/json, text/plain, */*");
+        client.DefaultRequestHeaders.Add("User-Agent", "TurboDocx API Client");
         
         var uploadResponse = await client.PostAsync("https://www.turbodocx.com/turbosign/documents/upload", uploadContent);
         var uploadResult = await uploadResponse.Content.ReadAsStringAsync();

--- a/static/scripts/turbosign/api/complete-workflow/csharp/minimal.cs
+++ b/static/scripts/turbosign/api/complete-workflow/csharp/minimal.cs
@@ -10,7 +10,7 @@ class Program
     // Configuration - Update these values
     private const string API_TOKEN = "YOUR_API_TOKEN";
     private const string ORG_ID = "YOUR_ORGANIZATION_ID";
-    private const string BASE_URL = "https://www.turbodocx.com/turbosign";
+    private const string BASE_URL = "https://api.turbodocx.com";
     private const string DOCUMENT_NAME = "Contract Agreement";
     static async Task Main(string[] args)
     {

--- a/static/scripts/turbosign/api/complete-workflow/csharp/minimal.cs
+++ b/static/scripts/turbosign/api/complete-workflow/csharp/minimal.cs
@@ -7,6 +7,11 @@ using System.Text.Json;
 
 class Program
 {
+    // Configuration - Update these values
+    private const string API_TOKEN = "YOUR_API_TOKEN";
+    private const string ORG_ID = "YOUR_ORGANIZATION_ID";
+    private const string BASE_URL = "https://www.turbodocx.com/turbosign";
+    private const string DOCUMENT_NAME = "Contract Agreement";
     static async Task Main(string[] args)
     {
         // Complete Workflow: Upload → Recipients → Prepare
@@ -14,17 +19,17 @@ class Program
         
         // Step 1: Upload Document
         using var uploadContent = new MultipartFormDataContent();
-        uploadContent.Add(new StringContent("Contract Agreement"), "name");
+        uploadContent.Add(new StringContent(DOCUMENT_NAME), "name");
         
         var fileContent = new ByteArrayContent(File.ReadAllBytes("./document.pdf"));
         fileContent.Headers.ContentType = new System.Net.Http.Headers.MediaTypeHeaderValue("application/pdf");
         uploadContent.Add(fileContent, "file", "document.pdf");
         
-        client.DefaultRequestHeaders.Add("Authorization", "Bearer YOUR_API_TOKEN");
-        client.DefaultRequestHeaders.Add("x-rapiddocx-org-id", "YOUR_ORGANIZATION_ID");
+        client.DefaultRequestHeaders.Add("Authorization", "Bearer " + API_TOKEN);
+        client.DefaultRequestHeaders.Add("x-rapiddocx-org-id", ORG_ID);
         client.DefaultRequestHeaders.Add("User-Agent", "TurboDocx API Client");
         
-        var uploadResponse = await client.PostAsync("https://www.turbodocx.com/turbosign/documents/upload", uploadContent);
+        var uploadResponse = await client.PostAsync(BASE_URL + "/documents/upload", uploadContent);
         var uploadResult = await uploadResponse.Content.ReadAsStringAsync();
         
         var uploadDoc = JsonDocument.Parse(uploadResult);
@@ -33,7 +38,7 @@ class Program
         // Step 2: Add Recipients
         var recipientPayload = @"{
           ""document"": {
-            ""name"": ""Contract Agreement - Updated"",
+            ""name"": """ + DOCUMENT_NAME + " - Updated"",
             ""description"": ""This document requires electronic signatures from both parties. Please review all content carefully before signing.""
           },
           ""recipients"": [
@@ -61,7 +66,7 @@ class Program
         }";
         
         var recipientContent = new StringContent(recipientPayload, Encoding.UTF8, "application/json");
-        var recipientResponse = await client.PostAsync($"https://www.turbodocx.com/turbosign/documents/{documentId}/update-with-recipients", recipientContent);
+        var recipientResponse = await client.PostAsync($"{BASE_URL}/documents/{documentId}/update-with-recipients", recipientContent);
         var recipientResult = await recipientResponse.Content.ReadAsStringAsync();
         
         var recipientDoc = JsonDocument.Parse(recipientResult);
@@ -128,7 +133,7 @@ class Program
         ]";
         
         var prepareContent = new StringContent(signaturePayload, Encoding.UTF8, "application/json");
-        var prepareResponse = await client.PostAsync($"https://www.turbodocx.com/turbosign/documents/{documentId}/prepare-for-signing", prepareContent);
+        var prepareResponse = await client.PostAsync($"{BASE_URL}/documents/{documentId}/prepare-for-signing", prepareContent);
         var finalResult = await prepareResponse.Content.ReadAsStringAsync();
         
         Console.WriteLine(finalResult);

--- a/static/scripts/turbosign/api/complete-workflow/go.go
+++ b/static/scripts/turbosign/api/complete-workflow/go.go
@@ -94,8 +94,8 @@ func main() {
 	
 	req2, _ := http.NewRequest("POST", fmt.Sprintf(BASE_URL+"/documents/%s/update-with-recipients", documentID), bytes.NewBufferString(recipientPayload))
 	req2.Header.Set("Content-Type", "application/json")
-	req2.Header.Set("Authorization", "Bearer YOUR_API_TOKEN")
-	req2.Header.Set("x-rapiddocx-org-id", "YOUR_ORGANIZATION_ID")
+	req2.Header.Set("Authorization", "Bearer "+API_TOKEN)
+	req2.Header.Set("x-rapiddocx-org-id", ORG_ID)
 	req2.Header.Set("User-Agent", "TurboDocx API Client")
 	
 	resp2, _ := client.Do(req2)
@@ -168,8 +168,8 @@ func main() {
 	
 	req3, _ := http.NewRequest("POST", fmt.Sprintf(BASE_URL+"/documents/%s/prepare-for-signing", documentID), bytes.NewBufferString(signaturePayload))
 	req3.Header.Set("Content-Type", "application/json")
-	req3.Header.Set("Authorization", "Bearer YOUR_API_TOKEN")
-	req3.Header.Set("x-rapiddocx-org-id", "YOUR_ORGANIZATION_ID")
+	req3.Header.Set("Authorization", "Bearer "+API_TOKEN)
+	req3.Header.Set("x-rapiddocx-org-id", ORG_ID)
 	req3.Header.Set("User-Agent", "TurboDocx API Client")
 	
 	resp3, _ := client.Do(req3)

--- a/static/scripts/turbosign/api/complete-workflow/go.go
+++ b/static/scripts/turbosign/api/complete-workflow/go.go
@@ -10,6 +10,14 @@ import (
 	"os"
 )
 
+// Configuration - Update these values
+const (
+	API_TOKEN = "YOUR_API_TOKEN"
+	ORG_ID = "YOUR_ORGANIZATION_ID"
+	BASE_URL = "https://www.turbodocx.com/turbosign"
+	DOCUMENT_NAME = "Contract Agreement"
+)
+
 type UploadResponse struct {
 	Data struct {
 		ID string `json:"id"`
@@ -31,7 +39,7 @@ func main() {
 	var buf bytes.Buffer
 	writer := multipart.NewWriter(&buf)
 	
-	writer.WriteField("name", "Contract Agreement")
+	writer.WriteField("name", DOCUMENT_NAME)
 	
 	file, _ := os.Open("./document.pdf")
 	defer file.Close()
@@ -39,9 +47,9 @@ func main() {
 	io.Copy(part, file)
 	writer.Close()
 	
-	req, _ := http.NewRequest("POST", "https://www.turbodocx.com/turbosign/documents/upload", &buf)
-	req.Header.Set("Authorization", "Bearer YOUR_API_TOKEN")
-	req.Header.Set("x-rapiddocx-org-id", "YOUR_ORGANIZATION_ID")
+	req, _ := http.NewRequest("POST", BASE_URL+"/documents/upload", &buf)
+	req.Header.Set("Authorization", "Bearer "+API_TOKEN)
+	req.Header.Set("x-rapiddocx-org-id", ORG_ID)
 	req.Header.Set("User-Agent", "TurboDocx API Client")
 	req.Header.Set("Content-Type", writer.FormDataContentType())
 	
@@ -57,7 +65,7 @@ func main() {
 	// Step 2: Add Recipients
 	recipientPayload := fmt.Sprintf(`{
 	  "document": {
-		"name": "Contract Agreement - Updated",
+		"name": "` + DOCUMENT_NAME + ` - Updated",
 		"description": "This document requires electronic signatures from both parties. Please review all content carefully before signing."
 	  },
 	  "recipients": [
@@ -84,7 +92,7 @@ func main() {
 	  ]
 	}`, documentID, documentID)
 	
-	req2, _ := http.NewRequest("POST", fmt.Sprintf("https://www.turbodocx.com/turbosign/documents/%s/update-with-recipients", documentID), bytes.NewBufferString(recipientPayload))
+	req2, _ := http.NewRequest("POST", fmt.Sprintf(BASE_URL+"/documents/%s/update-with-recipients", documentID), bytes.NewBufferString(recipientPayload))
 	req2.Header.Set("Content-Type", "application/json")
 	req2.Header.Set("Authorization", "Bearer YOUR_API_TOKEN")
 	req2.Header.Set("x-rapiddocx-org-id", "YOUR_ORGANIZATION_ID")
@@ -158,7 +166,7 @@ func main() {
 	  }
 	]`, recipients[0].ID, recipients[0].ID, recipients[1].ID, recipients[1].ID)
 	
-	req3, _ := http.NewRequest("POST", fmt.Sprintf("https://www.turbodocx.com/turbosign/documents/%s/prepare-for-signing", documentID), bytes.NewBufferString(signaturePayload))
+	req3, _ := http.NewRequest("POST", fmt.Sprintf(BASE_URL+"/documents/%s/prepare-for-signing", documentID), bytes.NewBufferString(signaturePayload))
 	req3.Header.Set("Content-Type", "application/json")
 	req3.Header.Set("Authorization", "Bearer YOUR_API_TOKEN")
 	req3.Header.Set("x-rapiddocx-org-id", "YOUR_ORGANIZATION_ID")

--- a/static/scripts/turbosign/api/complete-workflow/go.go
+++ b/static/scripts/turbosign/api/complete-workflow/go.go
@@ -14,7 +14,7 @@ import (
 const (
 	API_TOKEN = "YOUR_API_TOKEN"
 	ORG_ID = "YOUR_ORGANIZATION_ID"
-	BASE_URL = "https://www.turbodocx.com/turbosign"
+	BASE_URL = "https://api.turbodocx.com"
 	DOCUMENT_NAME = "Contract Agreement"
 )
 

--- a/static/scripts/turbosign/api/complete-workflow/go.go
+++ b/static/scripts/turbosign/api/complete-workflow/go.go
@@ -42,9 +42,7 @@ func main() {
 	req, _ := http.NewRequest("POST", "https://www.turbodocx.com/turbosign/documents/upload", &buf)
 	req.Header.Set("Authorization", "Bearer YOUR_API_TOKEN")
 	req.Header.Set("x-rapiddocx-org-id", "YOUR_ORGANIZATION_ID")
-	req.Header.Set("origin", "https://www.turbodocx.com")
-	req.Header.Set("referer", "https://www.turbodocx.com")
-	req.Header.Set("accept", "application/json, text/plain, */*")
+	req.Header.Set("User-Agent", "TurboDocx API Client")
 	req.Header.Set("Content-Type", writer.FormDataContentType())
 	
 	client := &http.Client{}
@@ -90,9 +88,7 @@ func main() {
 	req2.Header.Set("Content-Type", "application/json")
 	req2.Header.Set("Authorization", "Bearer YOUR_API_TOKEN")
 	req2.Header.Set("x-rapiddocx-org-id", "YOUR_ORGANIZATION_ID")
-	req2.Header.Set("origin", "https://www.turbodocx.com")
-	req2.Header.Set("referer", "https://www.turbodocx.com")
-	req2.Header.Set("accept", "application/json, text/plain, */*")
+	req2.Header.Set("User-Agent", "TurboDocx API Client")
 	
 	resp2, _ := client.Do(req2)
 	defer resp2.Body.Close()
@@ -166,9 +162,7 @@ func main() {
 	req3.Header.Set("Content-Type", "application/json")
 	req3.Header.Set("Authorization", "Bearer YOUR_API_TOKEN")
 	req3.Header.Set("x-rapiddocx-org-id", "YOUR_ORGANIZATION_ID")
-	req3.Header.Set("origin", "https://www.turbodocx.com")
-	req3.Header.Set("referer", "https://www.turbodocx.com")
-	req3.Header.Set("accept", "application/json, text/plain, */*")
+	req3.Header.Set("User-Agent", "TurboDocx API Client")
 	
 	resp3, _ := client.Do(req3)
 	defer resp3.Body.Close()

--- a/static/scripts/turbosign/api/complete-workflow/java.java
+++ b/static/scripts/turbosign/api/complete-workflow/java.java
@@ -33,9 +33,7 @@ public class TurboSignWorkflow {
             .uri(URI.create("https://www.turbodocx.com/turbosign/documents/upload"))
             .header("Authorization", "Bearer YOUR_API_TOKEN")
             .header("x-rapiddocx-org-id", "YOUR_ORGANIZATION_ID")
-            .header("origin", "https://www.turbodocx.com")
-            .header("referer", "https://www.turbodocx.com")
-            .header("accept", "application/json, text/plain, */*")
+            .header("User-Agent", "TurboDocx API Client")
             .header("Content-Type", "multipart/form-data; boundary=" + boundary)
             .POST(HttpRequest.BodyPublishers.ofByteArray(baos.toByteArray()))
             .build();
@@ -81,9 +79,7 @@ public class TurboSignWorkflow {
             .header("Content-Type", "application/json")
             .header("Authorization", "Bearer YOUR_API_TOKEN")
             .header("x-rapiddocx-org-id", "YOUR_ORGANIZATION_ID")
-            .header("origin", "https://www.turbodocx.com")
-            .header("referer", "https://www.turbodocx.com")
-            .header("accept", "application/json, text/plain, */*")
+            .header("User-Agent", "TurboDocx API Client")
             .POST(HttpRequest.BodyPublishers.ofString(recipientPayload))
             .build();
         
@@ -162,9 +158,7 @@ public class TurboSignWorkflow {
             .header("Content-Type", "application/json")
             .header("Authorization", "Bearer YOUR_API_TOKEN")
             .header("x-rapiddocx-org-id", "YOUR_ORGANIZATION_ID")
-            .header("origin", "https://www.turbodocx.com")
-            .header("referer", "https://www.turbodocx.com")
-            .header("accept", "application/json, text/plain, */*")
+            .header("User-Agent", "TurboDocx API Client")
             .POST(HttpRequest.BodyPublishers.ofString(signaturePayload))
             .build();
         

--- a/static/scripts/turbosign/api/complete-workflow/java.java
+++ b/static/scripts/turbosign/api/complete-workflow/java.java
@@ -6,6 +6,11 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.JsonNode;
 
 public class TurboSignWorkflow {
+    // Configuration - Update these values
+    private static final String API_TOKEN = "YOUR_API_TOKEN";
+    private static final String ORG_ID = "YOUR_ORGANIZATION_ID";
+    private static final String BASE_URL = "https://www.turbodocx.com/turbosign";
+    private static final String DOCUMENT_NAME = "Contract Agreement";
     public static void main(String[] args) throws Exception {
         // Complete Workflow: Upload → Recipients → Prepare
         HttpClient client = HttpClient.newHttpClient();
@@ -19,7 +24,7 @@ public class TurboSignWorkflow {
         StringBuilder formData = new StringBuilder();
         formData.append("--").append(boundary).append("\r\n");
         formData.append("Content-Disposition: form-data; name=\"name\"\r\n\r\n");
-        formData.append("Contract Agreement\r\n");
+        formData.append(DOCUMENT_NAME + "\r\n");
         formData.append("--").append(boundary).append("\r\n");
         formData.append("Content-Disposition: form-data; name=\"file\"; filename=\"document.pdf\"\r\n");
         formData.append("Content-Type: application/pdf\r\n\r\n");
@@ -30,9 +35,9 @@ public class TurboSignWorkflow {
         baos.write(("\r\n--" + boundary + "--\r\n").getBytes());
         
         HttpRequest uploadRequest = HttpRequest.newBuilder()
-            .uri(URI.create("https://www.turbodocx.com/turbosign/documents/upload"))
-            .header("Authorization", "Bearer YOUR_API_TOKEN")
-            .header("x-rapiddocx-org-id", "YOUR_ORGANIZATION_ID")
+            .uri(URI.create(BASE_URL + "/documents/upload"))
+            .header("Authorization", "Bearer " + API_TOKEN)
+            .header("x-rapiddocx-org-id", ORG_ID)
             .header("User-Agent", "TurboDocx API Client")
             .header("Content-Type", "multipart/form-data; boundary=" + boundary)
             .POST(HttpRequest.BodyPublishers.ofByteArray(baos.toByteArray()))
@@ -46,7 +51,7 @@ public class TurboSignWorkflow {
         String recipientPayload = String.format("""
         {
           "document": {
-            "name": "Contract Agreement - Updated",
+            "name": "" + DOCUMENT_NAME + " - Updated",
             "description": "This document requires electronic signatures from both parties. Please review all content carefully before signing."
           },
           "recipients": [
@@ -75,10 +80,10 @@ public class TurboSignWorkflow {
         """, documentId, documentId);
         
         HttpRequest recipientRequest = HttpRequest.newBuilder()
-            .uri(URI.create("https://www.turbodocx.com/turbosign/documents/" + documentId + "/update-with-recipients"))
+            .uri(URI.create(BASE_URL + "/documents/" + documentId + "/update-with-recipients"))
             .header("Content-Type", "application/json")
-            .header("Authorization", "Bearer YOUR_API_TOKEN")
-            .header("x-rapiddocx-org-id", "YOUR_ORGANIZATION_ID")
+            .header("Authorization", "Bearer " + API_TOKEN)
+            .header("x-rapiddocx-org-id", ORG_ID)
             .header("User-Agent", "TurboDocx API Client")
             .POST(HttpRequest.BodyPublishers.ofString(recipientPayload))
             .build();
@@ -154,10 +159,10 @@ public class TurboSignWorkflow {
         recipients.get(1).get("id").asText());
         
         HttpRequest prepareRequest = HttpRequest.newBuilder()
-            .uri(URI.create("https://www.turbodocx.com/turbosign/documents/" + documentId + "/prepare-for-signing"))
+            .uri(URI.create(BASE_URL + "/documents/" + documentId + "/prepare-for-signing"))
             .header("Content-Type", "application/json")
-            .header("Authorization", "Bearer YOUR_API_TOKEN")
-            .header("x-rapiddocx-org-id", "YOUR_ORGANIZATION_ID")
+            .header("Authorization", "Bearer " + API_TOKEN)
+            .header("x-rapiddocx-org-id", ORG_ID)
             .header("User-Agent", "TurboDocx API Client")
             .POST(HttpRequest.BodyPublishers.ofString(signaturePayload))
             .build();

--- a/static/scripts/turbosign/api/complete-workflow/java.java
+++ b/static/scripts/turbosign/api/complete-workflow/java.java
@@ -9,7 +9,7 @@ public class TurboSignWorkflow {
     // Configuration - Update these values
     private static final String API_TOKEN = "YOUR_API_TOKEN";
     private static final String ORG_ID = "YOUR_ORGANIZATION_ID";
-    private static final String BASE_URL = "https://www.turbodocx.com/turbosign";
+    private static final String BASE_URL = "https://api.turbodocx.com";
     private static final String DOCUMENT_NAME = "Contract Agreement";
     public static void main(String[] args) throws Exception {
         // Complete Workflow: Upload → Recipients → Prepare

--- a/static/scripts/turbosign/api/complete-workflow/nodejs/express.js
+++ b/static/scripts/turbosign/api/complete-workflow/nodejs/express.js
@@ -2,18 +2,24 @@ const FormData = require('form-data');
 const fs = require('fs');
 const fetch = require('node-fetch');
 
+// Configuration - Update these values
+const API_TOKEN = "YOUR_API_TOKEN";
+const ORG_ID = "YOUR_ORGANIZATION_ID";
+const BASE_URL = "https://www.turbodocx.com/turbosign";
+const DOCUMENT_NAME = "Contract Agreement";
+
 // Complete Workflow: Upload → Recipients → Prepare
 
 // Step 1: Upload Document
 const formData = new FormData();
-formData.append('name', 'Contract Agreement');
+formData.append('name', DOCUMENT_NAME);
 formData.append('file', fs.createReadStream('./document.pdf'));
 
-const uploadResponse = await fetch('https://www.turbodocx.com/turbosign/documents/upload', {
+const uploadResponse = await fetch(`${BASE_URL}/documents/upload`, {
   method: 'POST',
   headers: {
-    'Authorization': 'Bearer YOUR_API_TOKEN',
-    'x-rapiddocx-org-id': 'YOUR_ORGANIZATION_ID',
+    'Authorization': `Bearer ${API_TOKEN}`,
+    'x-rapiddocx-org-id': ORG_ID,
     'User-Agent': 'TurboDocx API Client',
     ...formData.getHeaders()
   },
@@ -26,7 +32,7 @@ const documentId = uploadResult.data.id;
 // Step 2: Add Recipients
 const recipientPayload = {
   "document": {
-    "name": "Contract Agreement - Updated",
+    "name": `${DOCUMENT_NAME} - Updated`,
     "description": "This document requires electronic signatures from both parties. Please review all content carefully before signing."
   },
   "recipients": [
@@ -53,12 +59,12 @@ const recipientPayload = {
   ]
 };
 
-const recipientResponse = await fetch(`https://www.turbodocx.com/turbosign/documents/${documentId}/update-with-recipients`, {
+const recipientResponse = await fetch(`${BASE_URL}/documents/${documentId}/update-with-recipients`, {
   method: 'POST',
   headers: {
     'Content-Type': 'application/json',
-    'Authorization': 'Bearer YOUR_API_TOKEN',
-    'x-rapiddocx-org-id': 'YOUR_ORGANIZATION_ID',
+    'Authorization': `Bearer ${API_TOKEN}`,
+    'x-rapiddocx-org-id': ORG_ID,
     'User-Agent': 'TurboDocx API Client'
   },
   body: JSON.stringify(recipientPayload)
@@ -127,12 +133,12 @@ const signatureFields = [
   }
 ];
 
-const prepareResponse = await fetch(`https://www.turbodocx.com/turbosign/documents/${documentId}/prepare-for-signing`, {
+const prepareResponse = await fetch(`${BASE_URL}/documents/${documentId}/prepare-for-signing`, {
   method: 'POST',
   headers: {
     'Content-Type': 'application/json',
-    'Authorization': 'Bearer YOUR_API_TOKEN',
-    'x-rapiddocx-org-id': 'YOUR_ORGANIZATION_ID',
+    'Authorization': `Bearer ${API_TOKEN}`,
+    'x-rapiddocx-org-id': ORG_ID,
     'User-Agent': 'TurboDocx API Client'
   },
   body: JSON.stringify(signatureFields)

--- a/static/scripts/turbosign/api/complete-workflow/nodejs/express.js
+++ b/static/scripts/turbosign/api/complete-workflow/nodejs/express.js
@@ -5,7 +5,7 @@ const fetch = require('node-fetch');
 // Configuration - Update these values
 const API_TOKEN = "YOUR_API_TOKEN";
 const ORG_ID = "YOUR_ORGANIZATION_ID";
-const BASE_URL = "https://www.turbodocx.com/turbosign";
+const BASE_URL = "https://api.turbodocx.com";
 const DOCUMENT_NAME = "Contract Agreement";
 
 // Complete Workflow: Upload → Recipients → Prepare

--- a/static/scripts/turbosign/api/complete-workflow/nodejs/express.js
+++ b/static/scripts/turbosign/api/complete-workflow/nodejs/express.js
@@ -14,9 +14,7 @@ const uploadResponse = await fetch('https://www.turbodocx.com/turbosign/document
   headers: {
     'Authorization': 'Bearer YOUR_API_TOKEN',
     'x-rapiddocx-org-id': 'YOUR_ORGANIZATION_ID',
-    'origin': 'https://www.turbodocx.com',
-    'referer': 'https://www.turbodocx.com',
-    'accept': 'application/json, text/plain, */*',
+    'User-Agent': 'TurboDocx API Client',
     ...formData.getHeaders()
   },
   body: formData
@@ -61,9 +59,7 @@ const recipientResponse = await fetch(`https://www.turbodocx.com/turbosign/docum
     'Content-Type': 'application/json',
     'Authorization': 'Bearer YOUR_API_TOKEN',
     'x-rapiddocx-org-id': 'YOUR_ORGANIZATION_ID',
-    'origin': 'https://www.turbodocx.com',
-    'referer': 'https://www.turbodocx.com',
-    'accept': 'application/json, text/plain, */*'
+    'User-Agent': 'TurboDocx API Client'
   },
   body: JSON.stringify(recipientPayload)
 });
@@ -137,9 +133,7 @@ const prepareResponse = await fetch(`https://www.turbodocx.com/turbosign/documen
     'Content-Type': 'application/json',
     'Authorization': 'Bearer YOUR_API_TOKEN',
     'x-rapiddocx-org-id': 'YOUR_ORGANIZATION_ID',
-    'origin': 'https://www.turbodocx.com',
-    'referer': 'https://www.turbodocx.com',
-    'accept': 'application/json, text/plain, */*'
+    'User-Agent': 'TurboDocx API Client'
   },
   body: JSON.stringify(signatureFields)
 });

--- a/static/scripts/turbosign/api/complete-workflow/nodejs/fastify.js
+++ b/static/scripts/turbosign/api/complete-workflow/nodejs/fastify.js
@@ -2,18 +2,24 @@ const FormData = require('form-data');
 const fs = require('fs');
 const fetch = require('node-fetch');
 
+// Configuration - Update these values
+const API_TOKEN = "YOUR_API_TOKEN";
+const ORG_ID = "YOUR_ORGANIZATION_ID";
+const BASE_URL = "https://www.turbodocx.com/turbosign";
+const DOCUMENT_NAME = "Contract Agreement";
+
 // Complete Workflow: Upload → Recipients → Prepare
 
 // Step 1: Upload Document
 const formData = new FormData();
-formData.append('name', 'Contract Agreement');
+formData.append('name', DOCUMENT_NAME);
 formData.append('file', fs.createReadStream('./document.pdf'));
 
-const uploadResponse = await fetch('https://www.turbodocx.com/turbosign/documents/upload', {
+const uploadResponse = await fetch(`${BASE_URL}/documents/upload`, {
   method: 'POST',
   headers: {
-    'Authorization': 'Bearer YOUR_API_TOKEN',
-    'x-rapiddocx-org-id': 'YOUR_ORGANIZATION_ID',
+    'Authorization': `Bearer ${API_TOKEN}`,
+    'x-rapiddocx-org-id': ORG_ID,
     'User-Agent': 'TurboDocx API Client',
     ...formData.getHeaders()
   },
@@ -26,7 +32,7 @@ const documentId = uploadResult.data.id;
 // Step 2: Add Recipients
 const recipientPayload = {
   "document": {
-    "name": "Contract Agreement - Updated",
+    "name": `${DOCUMENT_NAME} - Updated`,
     "description": "This document requires electronic signatures from both parties. Please review all content carefully before signing."
   },
   "recipients": [
@@ -53,12 +59,12 @@ const recipientPayload = {
   ]
 };
 
-const recipientResponse = await fetch(`https://www.turbodocx.com/turbosign/documents/${documentId}/update-with-recipients`, {
+const recipientResponse = await fetch(`${BASE_URL}/documents/${documentId}/update-with-recipients`, {
   method: 'POST',
   headers: {
     'Content-Type': 'application/json',
-    'Authorization': 'Bearer YOUR_API_TOKEN',
-    'x-rapiddocx-org-id': 'YOUR_ORGANIZATION_ID',
+    'Authorization': `Bearer ${API_TOKEN}`,
+    'x-rapiddocx-org-id': ORG_ID,
     'User-Agent': 'TurboDocx API Client'
   },
   body: JSON.stringify(recipientPayload)
@@ -127,12 +133,12 @@ const signatureFields = [
   }
 ];
 
-const prepareResponse = await fetch(`https://www.turbodocx.com/turbosign/documents/${documentId}/prepare-for-signing`, {
+const prepareResponse = await fetch(`${BASE_URL}/documents/${documentId}/prepare-for-signing`, {
   method: 'POST',
   headers: {
     'Content-Type': 'application/json',
-    'Authorization': 'Bearer YOUR_API_TOKEN',
-    'x-rapiddocx-org-id': 'YOUR_ORGANIZATION_ID',
+    'Authorization': `Bearer ${API_TOKEN}`,
+    'x-rapiddocx-org-id': ORG_ID,
     'User-Agent': 'TurboDocx API Client'
   },
   body: JSON.stringify(signatureFields)

--- a/static/scripts/turbosign/api/complete-workflow/nodejs/fastify.js
+++ b/static/scripts/turbosign/api/complete-workflow/nodejs/fastify.js
@@ -5,7 +5,7 @@ const fetch = require('node-fetch');
 // Configuration - Update these values
 const API_TOKEN = "YOUR_API_TOKEN";
 const ORG_ID = "YOUR_ORGANIZATION_ID";
-const BASE_URL = "https://www.turbodocx.com/turbosign";
+const BASE_URL = "https://api.turbodocx.com";
 const DOCUMENT_NAME = "Contract Agreement";
 
 // Complete Workflow: Upload → Recipients → Prepare

--- a/static/scripts/turbosign/api/complete-workflow/nodejs/fastify.js
+++ b/static/scripts/turbosign/api/complete-workflow/nodejs/fastify.js
@@ -14,9 +14,7 @@ const uploadResponse = await fetch('https://www.turbodocx.com/turbosign/document
   headers: {
     'Authorization': 'Bearer YOUR_API_TOKEN',
     'x-rapiddocx-org-id': 'YOUR_ORGANIZATION_ID',
-    'origin': 'https://www.turbodocx.com',
-    'referer': 'https://www.turbodocx.com',
-    'accept': 'application/json, text/plain, */*',
+    'User-Agent': 'TurboDocx API Client',
     ...formData.getHeaders()
   },
   body: formData
@@ -61,9 +59,7 @@ const recipientResponse = await fetch(`https://www.turbodocx.com/turbosign/docum
     'Content-Type': 'application/json',
     'Authorization': 'Bearer YOUR_API_TOKEN',
     'x-rapiddocx-org-id': 'YOUR_ORGANIZATION_ID',
-    'origin': 'https://www.turbodocx.com',
-    'referer': 'https://www.turbodocx.com',
-    'accept': 'application/json, text/plain, */*'
+    'User-Agent': 'TurboDocx API Client'
   },
   body: JSON.stringify(recipientPayload)
 });
@@ -137,9 +133,7 @@ const prepareResponse = await fetch(`https://www.turbodocx.com/turbosign/documen
     'Content-Type': 'application/json',
     'Authorization': 'Bearer YOUR_API_TOKEN',
     'x-rapiddocx-org-id': 'YOUR_ORGANIZATION_ID',
-    'origin': 'https://www.turbodocx.com',
-    'referer': 'https://www.turbodocx.com',
-    'accept': 'application/json, text/plain, */*'
+    'User-Agent': 'TurboDocx API Client'
   },
   body: JSON.stringify(signatureFields)
 });

--- a/static/scripts/turbosign/api/complete-workflow/php.php
+++ b/static/scripts/turbosign/api/complete-workflow/php.php
@@ -2,7 +2,7 @@
 // Configuration - Update these values
 $API_TOKEN = "YOUR_API_TOKEN";
 $ORG_ID = "YOUR_ORGANIZATION_ID";
-$BASE_URL = "https://www.turbodocx.com/turbosign";
+$BASE_URL = "https://api.turbodocx.com";
 $DOCUMENT_NAME = "Contract Agreement";
 
 // Complete Workflow: Upload → Recipients → Prepare

--- a/static/scripts/turbosign/api/complete-workflow/php.php
+++ b/static/scripts/turbosign/api/complete-workflow/php.php
@@ -13,9 +13,7 @@ $upload_data = [
 $upload_headers = [
     'Authorization: Bearer YOUR_API_TOKEN',
     'x-rapiddocx-org-id: YOUR_ORGANIZATION_ID',
-    'origin: https://www.turbodocx.com',
-    'referer: https://www.turbodocx.com',
-    'accept: application/json, text/plain, */*'
+    'User-Agent: TurboDocx API Client'
 ];
 
 $ch = curl_init();
@@ -67,9 +65,7 @@ $recipient_headers = [
     'Content-Type: application/json',
     'Authorization: Bearer YOUR_API_TOKEN',
     'x-rapiddocx-org-id: YOUR_ORGANIZATION_ID',
-    'origin: https://www.turbodocx.com',
-    'referer: https://www.turbodocx.com',
-    'accept: application/json, text/plain, */*'
+    'User-Agent: TurboDocx API Client'
 ];
 
 $ch = curl_init();
@@ -151,9 +147,7 @@ $prepare_headers = [
     'Content-Type: application/json',
     'Authorization: Bearer YOUR_API_TOKEN',
     'x-rapiddocx-org-id: YOUR_ORGANIZATION_ID',
-    'origin: https://www.turbodocx.com',
-    'referer: https://www.turbodocx.com',
-    'accept: application/json, text/plain, */*'
+    'User-Agent: TurboDocx API Client'
 ];
 
 $ch = curl_init();

--- a/static/scripts/turbosign/api/complete-workflow/php.php
+++ b/static/scripts/turbosign/api/complete-workflow/php.php
@@ -1,18 +1,24 @@
 <?php
+// Configuration - Update these values
+$API_TOKEN = "YOUR_API_TOKEN";
+$ORG_ID = "YOUR_ORGANIZATION_ID";
+$BASE_URL = "https://www.turbodocx.com/turbosign";
+$DOCUMENT_NAME = "Contract Agreement";
+
 // Complete Workflow: Upload → Recipients → Prepare
 
 // Step 1: Upload Document
-$upload_url = 'https://www.turbodocx.com/turbosign/documents/upload';
+$upload_url = $BASE_URL . '/documents/upload';
 
 $file_path = 'document.pdf';
 $upload_data = [
-    'name' => 'Contract Agreement',
+    'name' => $DOCUMENT_NAME,
     'file' => new CURLFile($file_path, 'application/pdf', 'document.pdf')
 ];
 
 $upload_headers = [
-    'Authorization: Bearer YOUR_API_TOKEN',
-    'x-rapiddocx-org-id: YOUR_ORGANIZATION_ID',
+    'Authorization: Bearer ' . $API_TOKEN,
+    'x-rapiddocx-org-id: ' . $ORG_ID,
     'User-Agent: TurboDocx API Client'
 ];
 
@@ -34,7 +40,7 @@ $document_id = $upload_result['data']['id'];
 // Step 2: Add Recipients
 $recipient_payload = [
     'document' => [
-        'name' => 'Contract Agreement - Updated',
+        'name' => $DOCUMENT_NAME . ' - Updated',
         'description' => 'This document requires electronic signatures from both parties. Please review all content carefully before signing.'
     ],
     'recipients' => [
@@ -63,14 +69,14 @@ $recipient_payload = [
 
 $recipient_headers = [
     'Content-Type: application/json',
-    'Authorization: Bearer YOUR_API_TOKEN',
-    'x-rapiddocx-org-id: YOUR_ORGANIZATION_ID',
+    'Authorization: Bearer ' . $API_TOKEN,
+    'x-rapiddocx-org-id: ' . $ORG_ID,
     'User-Agent: TurboDocx API Client'
 ];
 
 $ch = curl_init();
 curl_setopt_array($ch, [
-    CURLOPT_URL => "https://www.turbodocx.com/turbosign/documents/$document_id/update-with-recipients",
+    CURLOPT_URL => $BASE_URL . "/documents/$document_id/update-with-recipients",
     CURLOPT_POST => true,
     CURLOPT_POSTFIELDS => json_encode($recipient_payload),
     CURLOPT_HTTPHEADER => $recipient_headers,
@@ -145,14 +151,14 @@ $signature_fields = [
 
 $prepare_headers = [
     'Content-Type: application/json',
-    'Authorization: Bearer YOUR_API_TOKEN',
-    'x-rapiddocx-org-id: YOUR_ORGANIZATION_ID',
+    'Authorization: Bearer ' . $API_TOKEN,
+    'x-rapiddocx-org-id: ' . $ORG_ID,
     'User-Agent: TurboDocx API Client'
 ];
 
 $ch = curl_init();
 curl_setopt_array($ch, [
-    CURLOPT_URL => "https://www.turbodocx.com/turbosign/documents/$document_id/prepare-for-signing",
+    CURLOPT_URL => $BASE_URL . "/documents/$document_id/prepare-for-signing",
     CURLOPT_POST => true,
     CURLOPT_POSTFIELDS => json_encode($signature_fields),
     CURLOPT_HTTPHEADER => $prepare_headers,

--- a/static/scripts/turbosign/api/complete-workflow/powershell.ps1
+++ b/static/scripts/turbosign/api/complete-workflow/powershell.ps1
@@ -27,9 +27,7 @@ $uploadBody = New-Object byte[] ($formDataBytes.Length + $fileBytes.Length + $en
 $uploadHeaders = @{
     'Authorization' = 'Bearer YOUR_API_TOKEN'
     'x-rapiddocx-org-id' = 'YOUR_ORGANIZATION_ID'
-    'origin' = 'https://www.turbodocx.com'
-    'referer' = 'https://www.turbodocx.com'
-    'accept' = 'application/json, text/plain, */*'
+    'User-Agent' = 'TurboDocx API Client'
     'Content-Type' = "multipart/form-data; boundary=$boundary"
 }
 
@@ -70,9 +68,7 @@ $recipientHeaders = @{
     'Content-Type' = 'application/json'
     'Authorization' = 'Bearer YOUR_API_TOKEN'
     'x-rapiddocx-org-id' = 'YOUR_ORGANIZATION_ID'
-    'origin' = 'https://www.turbodocx.com'
-    'referer' = 'https://www.turbodocx.com'
-    'accept' = 'application/json, text/plain, */*'
+    'User-Agent' = 'TurboDocx API Client'
 }
 
 $recipientResponse = Invoke-RestMethod -Uri "https://www.turbodocx.com/turbosign/documents/$documentId/update-with-recipients" -Method Post -Body $recipientPayload -Headers $recipientHeaders -ContentType 'application/json'
@@ -142,9 +138,7 @@ $prepareHeaders = @{
     'Content-Type' = 'application/json'
     'Authorization' = 'Bearer YOUR_API_TOKEN'
     'x-rapiddocx-org-id' = 'YOUR_ORGANIZATION_ID'
-    'origin' = 'https://www.turbodocx.com'
-    'referer' = 'https://www.turbodocx.com'
-    'accept' = 'application/json, text/plain, */*'
+    'User-Agent' = 'TurboDocx API Client'
 }
 
 $finalResponse = Invoke-RestMethod -Uri "https://www.turbodocx.com/turbosign/documents/$documentId/prepare-for-signing" -Method Post -Body $signatureFields -Headers $prepareHeaders -ContentType 'application/json'

--- a/static/scripts/turbosign/api/complete-workflow/powershell.ps1
+++ b/static/scripts/turbosign/api/complete-workflow/powershell.ps1
@@ -1,7 +1,7 @@
 # Configuration - Update these values
 $API_TOKEN = "YOUR_API_TOKEN"
 $ORG_ID = "YOUR_ORGANIZATION_ID"
-$BASE_URL = "https://www.turbodocx.com/turbosign"
+$BASE_URL = "https://api.turbodocx.com"
 $DOCUMENT_NAME = "Contract Agreement"
 
 # Complete Workflow: Upload → Recipients → Prepare

--- a/static/scripts/turbosign/api/complete-workflow/powershell.ps1
+++ b/static/scripts/turbosign/api/complete-workflow/powershell.ps1
@@ -1,3 +1,9 @@
+# Configuration - Update these values
+$API_TOKEN = "YOUR_API_TOKEN"
+$ORG_ID = "YOUR_ORGANIZATION_ID"
+$BASE_URL = "https://www.turbodocx.com/turbosign"
+$DOCUMENT_NAME = "Contract Agreement"
+
 # Complete Workflow: Upload → Recipients → Prepare
 
 # Step 1: Upload Document
@@ -9,7 +15,7 @@ $formData = @"
 --$boundary
 Content-Disposition: form-data; name="name"
 
-Contract Agreement
+$DOCUMENT_NAME
 --$boundary
 Content-Disposition: form-data; name="file"; filename="document.pdf"
 Content-Type: application/pdf
@@ -25,19 +31,19 @@ $uploadBody = New-Object byte[] ($formDataBytes.Length + $fileBytes.Length + $en
 [Array]::Copy($endBoundary, 0, $uploadBody, $formDataBytes.Length + $fileBytes.Length, $endBoundary.Length)
 
 $uploadHeaders = @{
-    'Authorization' = 'Bearer YOUR_API_TOKEN'
-    'x-rapiddocx-org-id' = 'YOUR_ORGANIZATION_ID'
+    'Authorization' = "Bearer $API_TOKEN"
+    'x-rapiddocx-org-id' = $ORG_ID
     'User-Agent' = 'TurboDocx API Client'
     'Content-Type' = "multipart/form-data; boundary=$boundary"
 }
 
-$uploadResponse = Invoke-RestMethod -Uri "https://www.turbodocx.com/turbosign/documents/upload" -Method Post -Body $uploadBody -Headers $uploadHeaders
+$uploadResponse = Invoke-RestMethod -Uri "$BASE_URL/documents/upload" -Method Post -Body $uploadBody -Headers $uploadHeaders
 $documentId = $uploadResponse.data.id
 
 # Step 2: Add Recipients
 $recipientPayload = @{
     document = @{
-        name = "Contract Agreement - Updated"
+        name = "$DOCUMENT_NAME - Updated"
         description = "This document requires electronic signatures from both parties. Please review all content carefully before signing."
     }
     recipients = @(
@@ -66,12 +72,12 @@ $recipientPayload = @{
 
 $recipientHeaders = @{
     'Content-Type' = 'application/json'
-    'Authorization' = 'Bearer YOUR_API_TOKEN'
-    'x-rapiddocx-org-id' = 'YOUR_ORGANIZATION_ID'
+    'Authorization' = "Bearer $API_TOKEN"
+    'x-rapiddocx-org-id' = $ORG_ID
     'User-Agent' = 'TurboDocx API Client'
 }
 
-$recipientResponse = Invoke-RestMethod -Uri "https://www.turbodocx.com/turbosign/documents/$documentId/update-with-recipients" -Method Post -Body $recipientPayload -Headers $recipientHeaders -ContentType 'application/json'
+$recipientResponse = Invoke-RestMethod -Uri "$BASE_URL/documents/$documentId/update-with-recipients" -Method Post -Body $recipientPayload -Headers $recipientHeaders -ContentType 'application/json'
 $recipients = $recipientResponse.data.recipients
 
 # Step 3: Prepare for Signing
@@ -136,10 +142,10 @@ $signatureFields = @(
 
 $prepareHeaders = @{
     'Content-Type' = 'application/json'
-    'Authorization' = 'Bearer YOUR_API_TOKEN'
-    'x-rapiddocx-org-id' = 'YOUR_ORGANIZATION_ID'
+    'Authorization' = "Bearer $API_TOKEN"
+    'x-rapiddocx-org-id' = $ORG_ID
     'User-Agent' = 'TurboDocx API Client'
 }
 
-$finalResponse = Invoke-RestMethod -Uri "https://www.turbodocx.com/turbosign/documents/$documentId/prepare-for-signing" -Method Post -Body $signatureFields -Headers $prepareHeaders -ContentType 'application/json'
+$finalResponse = Invoke-RestMethod -Uri "$BASE_URL/documents/$documentId/prepare-for-signing" -Method Post -Body $signatureFields -Headers $prepareHeaders -ContentType 'application/json'
 $finalResponse | ConvertTo-Json

--- a/static/scripts/turbosign/api/complete-workflow/python/fastapi.py
+++ b/static/scripts/turbosign/api/complete-workflow/python/fastapi.py
@@ -13,9 +13,7 @@ upload_response = requests.post(
     headers={
         'Authorization': 'Bearer YOUR_API_TOKEN',
         'x-rapiddocx-org-id': 'YOUR_ORGANIZATION_ID',
-        'origin': 'https://www.turbodocx.com',
-        'referer': 'https://www.turbodocx.com',
-        'accept': 'application/json, text/plain, */*'
+        'User-Agent': 'TurboDocx API Client'
     },
     files=files
 )
@@ -59,9 +57,7 @@ recipient_response = requests.post(
         'Content-Type': 'application/json',
         'Authorization': 'Bearer YOUR_API_TOKEN',
         'x-rapiddocx-org-id': 'YOUR_ORGANIZATION_ID',
-        'origin': 'https://www.turbodocx.com',
-        'referer': 'https://www.turbodocx.com',
-        'accept': 'application/json, text/plain, */*'
+        'User-Agent': 'TurboDocx API Client'
     },
     json=recipient_payload
 )
@@ -135,9 +131,7 @@ prepare_response = requests.post(
         'Content-Type': 'application/json',
         'Authorization': 'Bearer YOUR_API_TOKEN',
         'x-rapiddocx-org-id': 'YOUR_ORGANIZATION_ID',
-        'origin': 'https://www.turbodocx.com',
-        'referer': 'https://www.turbodocx.com',
-        'accept': 'application/json, text/plain, */*'
+        'User-Agent': 'TurboDocx API Client'
     },
     json=signature_fields
 )

--- a/static/scripts/turbosign/api/complete-workflow/python/fastapi.py
+++ b/static/scripts/turbosign/api/complete-workflow/python/fastapi.py
@@ -1,18 +1,24 @@
 import requests
 
+# Configuration - Update these values
+API_TOKEN = "YOUR_API_TOKEN"
+ORG_ID = "YOUR_ORGANIZATION_ID"
+BASE_URL = "https://www.turbodocx.com/turbosign"
+DOCUMENT_NAME = "Contract Agreement"
+
 # Complete Workflow: Upload → Recipients → Prepare
 
 # Step 1: Upload Document
 files = {
-    'name': (None, 'Contract Agreement'),
+    'name': (None, DOCUMENT_NAME),
     'file': ('document.pdf', open('document.pdf', 'rb'), 'application/pdf')
 }
 
 upload_response = requests.post(
-    'https://www.turbodocx.com/turbosign/documents/upload',
+    f'{BASE_URL}/documents/upload',
     headers={
-        'Authorization': 'Bearer YOUR_API_TOKEN',
-        'x-rapiddocx-org-id': 'YOUR_ORGANIZATION_ID',
+        'Authorization': f'Bearer {API_TOKEN}',
+        'x-rapiddocx-org-id': ORG_ID,
         'User-Agent': 'TurboDocx API Client'
     },
     files=files
@@ -24,7 +30,7 @@ document_id = upload_result['data']['id']
 # Step 2: Add Recipients
 recipient_payload = {
     "document": {
-        "name": "Contract Agreement - Updated",
+        "name": f"{DOCUMENT_NAME} - Updated",
         "description": "This document requires electronic signatures from both parties. Please review all content carefully before signing."
     },
     "recipients": [
@@ -52,11 +58,11 @@ recipient_payload = {
 }
 
 recipient_response = requests.post(
-    f'https://www.turbodocx.com/turbosign/documents/{document_id}/update-with-recipients',
+    f'{BASE_URL}/documents/{document_id}/update-with-recipients',
     headers={
         'Content-Type': 'application/json',
-        'Authorization': 'Bearer YOUR_API_TOKEN',
-        'x-rapiddocx-org-id': 'YOUR_ORGANIZATION_ID',
+        'Authorization': f'Bearer {API_TOKEN}',
+        'x-rapiddocx-org-id': ORG_ID,
         'User-Agent': 'TurboDocx API Client'
     },
     json=recipient_payload
@@ -126,11 +132,11 @@ signature_fields = [
 ]
 
 prepare_response = requests.post(
-    f'https://www.turbodocx.com/turbosign/documents/{document_id}/prepare-for-signing',
+    f'{BASE_URL}/documents/{document_id}/prepare-for-signing',
     headers={
         'Content-Type': 'application/json',
-        'Authorization': 'Bearer YOUR_API_TOKEN',
-        'x-rapiddocx-org-id': 'YOUR_ORGANIZATION_ID',
+        'Authorization': f'Bearer {API_TOKEN}',
+        'x-rapiddocx-org-id': ORG_ID,
         'User-Agent': 'TurboDocx API Client'
     },
     json=signature_fields

--- a/static/scripts/turbosign/api/complete-workflow/python/fastapi.py
+++ b/static/scripts/turbosign/api/complete-workflow/python/fastapi.py
@@ -3,7 +3,7 @@ import requests
 # Configuration - Update these values
 API_TOKEN = "YOUR_API_TOKEN"
 ORG_ID = "YOUR_ORGANIZATION_ID"
-BASE_URL = "https://www.turbodocx.com/turbosign"
+BASE_URL = "https://api.turbodocx.com"
 DOCUMENT_NAME = "Contract Agreement"
 
 # Complete Workflow: Upload → Recipients → Prepare

--- a/static/scripts/turbosign/api/complete-workflow/python/flask.py
+++ b/static/scripts/turbosign/api/complete-workflow/python/flask.py
@@ -13,9 +13,7 @@ upload_response = requests.post(
     headers={
         'Authorization': 'Bearer YOUR_API_TOKEN',
         'x-rapiddocx-org-id': 'YOUR_ORGANIZATION_ID',
-        'origin': 'https://www.turbodocx.com',
-        'referer': 'https://www.turbodocx.com',
-        'accept': 'application/json, text/plain, */*'
+        'User-Agent': 'TurboDocx API Client'
     },
     files=files
 )
@@ -59,9 +57,7 @@ recipient_response = requests.post(
         'Content-Type': 'application/json',
         'Authorization': 'Bearer YOUR_API_TOKEN',
         'x-rapiddocx-org-id': 'YOUR_ORGANIZATION_ID',
-        'origin': 'https://www.turbodocx.com',
-        'referer': 'https://www.turbodocx.com',
-        'accept': 'application/json, text/plain, */*'
+        'User-Agent': 'TurboDocx API Client'
     },
     json=recipient_payload
 )
@@ -135,9 +131,7 @@ prepare_response = requests.post(
         'Content-Type': 'application/json',
         'Authorization': 'Bearer YOUR_API_TOKEN',
         'x-rapiddocx-org-id': 'YOUR_ORGANIZATION_ID',
-        'origin': 'https://www.turbodocx.com',
-        'referer': 'https://www.turbodocx.com',
-        'accept': 'application/json, text/plain, */*'
+        'User-Agent': 'TurboDocx API Client'
     },
     json=signature_fields
 )

--- a/static/scripts/turbosign/api/complete-workflow/python/flask.py
+++ b/static/scripts/turbosign/api/complete-workflow/python/flask.py
@@ -1,18 +1,24 @@
 import requests
 
+# Configuration - Update these values
+API_TOKEN = "YOUR_API_TOKEN"
+ORG_ID = "YOUR_ORGANIZATION_ID"
+BASE_URL = "https://www.turbodocx.com/turbosign"
+DOCUMENT_NAME = "Contract Agreement"
+
 # Complete Workflow: Upload → Recipients → Prepare
 
 # Step 1: Upload Document
 files = {
-    'name': (None, 'Contract Agreement'),
+    'name': (None, DOCUMENT_NAME),
     'file': ('document.pdf', open('document.pdf', 'rb'), 'application/pdf')
 }
 
 upload_response = requests.post(
-    'https://www.turbodocx.com/turbosign/documents/upload',
+    f'{BASE_URL}/documents/upload',
     headers={
-        'Authorization': 'Bearer YOUR_API_TOKEN',
-        'x-rapiddocx-org-id': 'YOUR_ORGANIZATION_ID',
+        'Authorization': f'Bearer {API_TOKEN}',
+        'x-rapiddocx-org-id': ORG_ID,
         'User-Agent': 'TurboDocx API Client'
     },
     files=files
@@ -24,7 +30,7 @@ document_id = upload_result['data']['id']
 # Step 2: Add Recipients
 recipient_payload = {
     "document": {
-        "name": "Contract Agreement - Updated",
+        "name": f"{DOCUMENT_NAME} - Updated",
         "description": "This document requires electronic signatures from both parties. Please review all content carefully before signing."
     },
     "recipients": [
@@ -52,11 +58,11 @@ recipient_payload = {
 }
 
 recipient_response = requests.post(
-    f'https://www.turbodocx.com/turbosign/documents/{document_id}/update-with-recipients',
+    f'{BASE_URL}/documents/{document_id}/update-with-recipients',
     headers={
         'Content-Type': 'application/json',
-        'Authorization': 'Bearer YOUR_API_TOKEN',
-        'x-rapiddocx-org-id': 'YOUR_ORGANIZATION_ID',
+        'Authorization': f'Bearer {API_TOKEN}',
+        'x-rapiddocx-org-id': ORG_ID,
         'User-Agent': 'TurboDocx API Client'
     },
     json=recipient_payload
@@ -126,11 +132,11 @@ signature_fields = [
 ]
 
 prepare_response = requests.post(
-    f'https://www.turbodocx.com/turbosign/documents/{document_id}/prepare-for-signing',
+    f'{BASE_URL}/documents/{document_id}/prepare-for-signing',
     headers={
         'Content-Type': 'application/json',
-        'Authorization': 'Bearer YOUR_API_TOKEN',
-        'x-rapiddocx-org-id': 'YOUR_ORGANIZATION_ID',
+        'Authorization': f'Bearer {API_TOKEN}',
+        'x-rapiddocx-org-id': ORG_ID,
         'User-Agent': 'TurboDocx API Client'
     },
     json=signature_fields

--- a/static/scripts/turbosign/api/complete-workflow/python/flask.py
+++ b/static/scripts/turbosign/api/complete-workflow/python/flask.py
@@ -3,7 +3,7 @@ import requests
 # Configuration - Update these values
 API_TOKEN = "YOUR_API_TOKEN"
 ORG_ID = "YOUR_ORGANIZATION_ID"
-BASE_URL = "https://www.turbodocx.com/turbosign"
+BASE_URL = "https://api.turbodocx.com"
 DOCUMENT_NAME = "Contract Agreement"
 
 # Complete Workflow: Upload → Recipients → Prepare

--- a/static/scripts/turbosign/api/complete-workflow/ruby.rb
+++ b/static/scripts/turbosign/api/complete-workflow/ruby.rb
@@ -24,9 +24,7 @@ http.use_ssl = true
 request = Net::HTTP::Post.new(uri)
 request['Authorization'] = 'Bearer YOUR_API_TOKEN'
 request['x-rapiddocx-org-id'] = 'YOUR_ORGANIZATION_ID'
-request['origin'] = 'https://www.turbodocx.com'
-request['referer'] = 'https://www.turbodocx.com'
-request['accept'] = 'application/json, text/plain, */*'
+request['User-Agent'] = 'TurboDocx API Client'
 request['Content-Type'] = "multipart/form-data; boundary=#{boundary}"
 request.body = form_data
 
@@ -70,9 +68,7 @@ request2 = Net::HTTP::Post.new(uri2)
 request2['Content-Type'] = 'application/json'
 request2['Authorization'] = 'Bearer YOUR_API_TOKEN'
 request2['x-rapiddocx-org-id'] = 'YOUR_ORGANIZATION_ID'
-request2['origin'] = 'https://www.turbodocx.com'
-request2['referer'] = 'https://www.turbodocx.com'
-request2['accept'] = 'application/json, text/plain, */*'
+request2['User-Agent'] = 'TurboDocx API Client'
 request2.body = recipient_payload.to_json
 
 recipient_response = http.request(request2)
@@ -145,9 +141,7 @@ request3 = Net::HTTP::Post.new(uri3)
 request3['Content-Type'] = 'application/json'
 request3['Authorization'] = 'Bearer YOUR_API_TOKEN'
 request3['x-rapiddocx-org-id'] = 'YOUR_ORGANIZATION_ID'
-request3['origin'] = 'https://www.turbodocx.com'
-request3['referer'] = 'https://www.turbodocx.com'
-request3['accept'] = 'application/json, text/plain, */*'
+request3['User-Agent'] = 'TurboDocx API Client'
 request3.body = signature_fields.to_json
 
 prepare_response = http.request(request3)

--- a/static/scripts/turbosign/api/complete-workflow/ruby.rb
+++ b/static/scripts/turbosign/api/complete-workflow/ruby.rb
@@ -5,7 +5,7 @@ require 'json'
 # Configuration - Update these values
 API_TOKEN = "YOUR_API_TOKEN"
 ORG_ID = "YOUR_ORGANIZATION_ID"
-BASE_URL = "https://www.turbodocx.com/turbosign"
+BASE_URL = "https://api.turbodocx.com"
 DOCUMENT_NAME = "Contract Agreement"
 
 # Complete Workflow: Upload → Recipients → Prepare

--- a/static/scripts/turbosign/api/complete-workflow/ruby.rb
+++ b/static/scripts/turbosign/api/complete-workflow/ruby.rb
@@ -2,16 +2,22 @@ require 'net/http'
 require 'uri'
 require 'json'
 
+# Configuration - Update these values
+API_TOKEN = "YOUR_API_TOKEN"
+ORG_ID = "YOUR_ORGANIZATION_ID"
+BASE_URL = "https://www.turbodocx.com/turbosign"
+DOCUMENT_NAME = "Contract Agreement"
+
 # Complete Workflow: Upload → Recipients → Prepare
 
 # Step 1: Upload Document
-uri = URI('https://www.turbodocx.com/turbosign/documents/upload')
+uri = URI("#{BASE_URL}/documents/upload")
 boundary = "----RubyBoundary#{rand(1000000)}"
 
 form_data = ""
 form_data << "--#{boundary}\r\n"
 form_data << "Content-Disposition: form-data; name=\"name\"\r\n\r\n"
-form_data << "Contract Agreement\r\n"
+form_data << "#{DOCUMENT_NAME}\r\n"
 form_data << "--#{boundary}\r\n"
 form_data << "Content-Disposition: form-data; name=\"file\"; filename=\"document.pdf\"\r\n"
 form_data << "Content-Type: application/pdf\r\n\r\n"
@@ -22,8 +28,8 @@ http = Net::HTTP.new(uri.host, uri.port)
 http.use_ssl = true
 
 request = Net::HTTP::Post.new(uri)
-request['Authorization'] = 'Bearer YOUR_API_TOKEN'
-request['x-rapiddocx-org-id'] = 'YOUR_ORGANIZATION_ID'
+request['Authorization'] = "Bearer #{API_TOKEN}"
+request['x-rapiddocx-org-id'] = ORG_ID
 request['User-Agent'] = 'TurboDocx API Client'
 request['Content-Type'] = "multipart/form-data; boundary=#{boundary}"
 request.body = form_data
@@ -35,7 +41,7 @@ document_id = upload_result['data']['id']
 # Step 2: Add Recipients
 recipient_payload = {
   "document" => {
-    "name" => "Contract Agreement - Updated",
+    "name" => "#{DOCUMENT_NAME} - Updated",
     "description" => "This document requires electronic signatures from both parties. Please review all content carefully before signing."
   },
   "recipients" => [
@@ -62,12 +68,12 @@ recipient_payload = {
   ]
 }
 
-uri2 = URI("https://www.turbodocx.com/turbosign/documents/#{document_id}/update-with-recipients")
+uri2 = URI("#{BASE_URL}/documents/#{document_id}/update-with-recipients")
 
 request2 = Net::HTTP::Post.new(uri2)
 request2['Content-Type'] = 'application/json'
-request2['Authorization'] = 'Bearer YOUR_API_TOKEN'
-request2['x-rapiddocx-org-id'] = 'YOUR_ORGANIZATION_ID'
+request2['Authorization'] = "Bearer #{API_TOKEN}"
+request2['x-rapiddocx-org-id'] = ORG_ID
 request2['User-Agent'] = 'TurboDocx API Client'
 request2.body = recipient_payload.to_json
 
@@ -135,12 +141,12 @@ signature_fields = [
   }
 ]
 
-uri3 = URI("https://www.turbodocx.com/turbosign/documents/#{document_id}/prepare-for-signing")
+uri3 = URI("#{BASE_URL}/documents/#{document_id}/prepare-for-signing")
 
 request3 = Net::HTTP::Post.new(uri3)
 request3['Content-Type'] = 'application/json'
-request3['Authorization'] = 'Bearer YOUR_API_TOKEN'
-request3['x-rapiddocx-org-id'] = 'YOUR_ORGANIZATION_ID'
+request3['Authorization'] = "Bearer #{API_TOKEN}"
+request3['x-rapiddocx-org-id'] = ORG_ID
 request3['User-Agent'] = 'TurboDocx API Client'
 request3.body = signature_fields.to_json
 

--- a/static/scripts/turbosign/api/step1-upload/csharp/controller.cs
+++ b/static/scripts/turbosign/api/step1-upload/csharp/controller.cs
@@ -8,7 +8,7 @@ class Program
     // Configuration - Update these values
     private const string API_TOKEN = "YOUR_API_TOKEN";
     private const string ORG_ID = "YOUR_ORGANIZATION_ID";
-    private const string BASE_URL = "https://www.turbodocx.com/turbosign";
+    private const string BASE_URL = "https://api.turbodocx.com";
     private const string DOCUMENT_NAME = "Contract Agreement";
     static async Task Main(string[] args)
     {

--- a/static/scripts/turbosign/api/step1-upload/csharp/controller.cs
+++ b/static/scripts/turbosign/api/step1-upload/csharp/controller.cs
@@ -5,23 +5,28 @@ using System.Threading.Tasks;
 
 class Program
 {
+    // Configuration - Update these values
+    private const string API_TOKEN = "YOUR_API_TOKEN";
+    private const string ORG_ID = "YOUR_ORGANIZATION_ID";
+    private const string BASE_URL = "https://www.turbodocx.com/turbosign";
+    private const string DOCUMENT_NAME = "Contract Agreement";
     static async Task Main(string[] args)
     {
         // Step 1: Upload Document
         using var client = new HttpClient();
         
-        client.DefaultRequestHeaders.Add("Authorization", "Bearer YOUR_API_TOKEN");
-        client.DefaultRequestHeaders.Add("x-rapiddocx-org-id", "YOUR_ORGANIZATION_ID");
+        client.DefaultRequestHeaders.Add("Authorization", "Bearer " + API_TOKEN);
+        client.DefaultRequestHeaders.Add("x-rapiddocx-org-id", ORG_ID);
         client.DefaultRequestHeaders.Add("User-Agent", "TurboDocx API Client");
         
         using var content = new MultipartFormDataContent();
-        content.Add(new StringContent("Contract Agreement"), "name");
+        content.Add(new StringContent(DOCUMENT_NAME), "name");
         
         var fileContent = new ByteArrayContent(File.ReadAllBytes("./document.pdf"));
         fileContent.Headers.ContentType = new System.Net.Http.Headers.MediaTypeHeaderValue("application/pdf");
         content.Add(fileContent, "file", "document.pdf");
         
-        var response = await client.PostAsync("https://www.turbodocx.com/turbosign/documents/upload", content);
+        var response = await client.PostAsync(BASE_URL + "/documents/upload", content);
         var result = await response.Content.ReadAsStringAsync();
         
         Console.WriteLine(result);

--- a/static/scripts/turbosign/api/step1-upload/csharp/controller.cs
+++ b/static/scripts/turbosign/api/step1-upload/csharp/controller.cs
@@ -12,9 +12,7 @@ class Program
         
         client.DefaultRequestHeaders.Add("Authorization", "Bearer YOUR_API_TOKEN");
         client.DefaultRequestHeaders.Add("x-rapiddocx-org-id", "YOUR_ORGANIZATION_ID");
-        client.DefaultRequestHeaders.Add("origin", "https://www.turbodocx.com");
-        client.DefaultRequestHeaders.Add("referer", "https://www.turbodocx.com");
-        client.DefaultRequestHeaders.Add("accept", "application/json, text/plain, */*");
+        client.DefaultRequestHeaders.Add("User-Agent", "TurboDocx API Client");
         
         using var content = new MultipartFormDataContent();
         content.Add(new StringContent("Contract Agreement"), "name");

--- a/static/scripts/turbosign/api/step1-upload/csharp/minimal.cs
+++ b/static/scripts/turbosign/api/step1-upload/csharp/minimal.cs
@@ -8,7 +8,7 @@ class Program
     // Configuration - Update these values
     private const string API_TOKEN = "YOUR_API_TOKEN";
     private const string ORG_ID = "YOUR_ORGANIZATION_ID";
-    private const string BASE_URL = "https://www.turbodocx.com/turbosign";
+    private const string BASE_URL = "https://api.turbodocx.com";
     private const string DOCUMENT_NAME = "Contract Agreement";
     static async Task Main(string[] args)
     {

--- a/static/scripts/turbosign/api/step1-upload/csharp/minimal.cs
+++ b/static/scripts/turbosign/api/step1-upload/csharp/minimal.cs
@@ -5,23 +5,28 @@ using System.Threading.Tasks;
 
 class Program
 {
+    // Configuration - Update these values
+    private const string API_TOKEN = "YOUR_API_TOKEN";
+    private const string ORG_ID = "YOUR_ORGANIZATION_ID";
+    private const string BASE_URL = "https://www.turbodocx.com/turbosign";
+    private const string DOCUMENT_NAME = "Contract Agreement";
     static async Task Main(string[] args)
     {
         // Step 1: Upload Document
         using var client = new HttpClient();
         
-        client.DefaultRequestHeaders.Add("Authorization", "Bearer YOUR_API_TOKEN");
-        client.DefaultRequestHeaders.Add("x-rapiddocx-org-id", "YOUR_ORGANIZATION_ID");
+        client.DefaultRequestHeaders.Add("Authorization", "Bearer " + API_TOKEN);
+        client.DefaultRequestHeaders.Add("x-rapiddocx-org-id", ORG_ID);
         client.DefaultRequestHeaders.Add("User-Agent", "TurboDocx API Client");
         
         using var content = new MultipartFormDataContent();
-        content.Add(new StringContent("Contract Agreement"), "name");
+        content.Add(new StringContent(DOCUMENT_NAME), "name");
         
         var fileContent = new ByteArrayContent(File.ReadAllBytes("./document.pdf"));
         fileContent.Headers.ContentType = new System.Net.Http.Headers.MediaTypeHeaderValue("application/pdf");
         content.Add(fileContent, "file", "document.pdf");
         
-        var response = await client.PostAsync("https://www.turbodocx.com/turbosign/documents/upload", content);
+        var response = await client.PostAsync(BASE_URL + "/documents/upload", content);
         var result = await response.Content.ReadAsStringAsync();
         
         Console.WriteLine(result);

--- a/static/scripts/turbosign/api/step1-upload/csharp/minimal.cs
+++ b/static/scripts/turbosign/api/step1-upload/csharp/minimal.cs
@@ -12,9 +12,7 @@ class Program
         
         client.DefaultRequestHeaders.Add("Authorization", "Bearer YOUR_API_TOKEN");
         client.DefaultRequestHeaders.Add("x-rapiddocx-org-id", "YOUR_ORGANIZATION_ID");
-        client.DefaultRequestHeaders.Add("origin", "https://www.turbodocx.com");
-        client.DefaultRequestHeaders.Add("referer", "https://www.turbodocx.com");
-        client.DefaultRequestHeaders.Add("accept", "application/json, text/plain, */*");
+        client.DefaultRequestHeaders.Add("User-Agent", "TurboDocx API Client");
         
         using var content = new MultipartFormDataContent();
         content.Add(new StringContent("Contract Agreement"), "name");

--- a/static/scripts/turbosign/api/step1-upload/go.go
+++ b/static/scripts/turbosign/api/step1-upload/go.go
@@ -24,9 +24,7 @@ func main() {
 	req, _ := http.NewRequest("POST", "https://www.turbodocx.com/turbosign/documents/upload", &buf)
 	req.Header.Set("Authorization", "Bearer YOUR_API_TOKEN")
 	req.Header.Set("x-rapiddocx-org-id", "YOUR_ORGANIZATION_ID")
-	req.Header.Set("origin", "https://www.turbodocx.com")
-	req.Header.Set("referer", "https://www.turbodocx.com")
-	req.Header.Set("accept", "application/json, text/plain, */*")
+	req.Header.Set("User-Agent", "TurboDocx API Client")
 	req.Header.Set("Content-Type", writer.FormDataContentType())
 	
 	client := &http.Client{}

--- a/static/scripts/turbosign/api/step1-upload/go.go
+++ b/static/scripts/turbosign/api/step1-upload/go.go
@@ -12,7 +12,7 @@ import (
 const (
 	API_TOKEN = "YOUR_API_TOKEN"
 	ORG_ID = "YOUR_ORGANIZATION_ID"
-	BASE_URL = "https://www.turbodocx.com/turbosign"
+	BASE_URL = "https://api.turbodocx.com"
 	DOCUMENT_NAME = "Contract Agreement"
 )
 

--- a/static/scripts/turbosign/api/step1-upload/go.go
+++ b/static/scripts/turbosign/api/step1-upload/go.go
@@ -8,12 +8,20 @@ import (
 	"os"
 )
 
+// Configuration - Update these values
+const (
+	API_TOKEN = "YOUR_API_TOKEN"
+	ORG_ID = "YOUR_ORGANIZATION_ID"
+	BASE_URL = "https://www.turbodocx.com/turbosign"
+	DOCUMENT_NAME = "Contract Agreement"
+)
+
 func main() {
 	// Step 1: Upload Document
 	var buf bytes.Buffer
 	writer := multipart.NewWriter(&buf)
 	
-	writer.WriteField("name", "Contract Agreement")
+	writer.WriteField("name", DOCUMENT_NAME)
 	
 	file, _ := os.Open("./document.pdf")
 	defer file.Close()
@@ -21,9 +29,9 @@ func main() {
 	io.Copy(part, file)
 	writer.Close()
 	
-	req, _ := http.NewRequest("POST", "https://www.turbodocx.com/turbosign/documents/upload", &buf)
-	req.Header.Set("Authorization", "Bearer YOUR_API_TOKEN")
-	req.Header.Set("x-rapiddocx-org-id", "YOUR_ORGANIZATION_ID")
+	req, _ := http.NewRequest("POST", BASE_URL+"/documents/upload", &buf)
+	req.Header.Set("Authorization", "Bearer "+API_TOKEN)
+	req.Header.Set("x-rapiddocx-org-id", ORG_ID)
 	req.Header.Set("User-Agent", "TurboDocx API Client")
 	req.Header.Set("Content-Type", writer.FormDataContentType())
 	

--- a/static/scripts/turbosign/api/step1-upload/java.java
+++ b/static/scripts/turbosign/api/step1-upload/java.java
@@ -28,9 +28,7 @@ public class TurboSignUpload {
             .uri(URI.create("https://www.turbodocx.com/turbosign/documents/upload"))
             .header("Authorization", "Bearer YOUR_API_TOKEN")
             .header("x-rapiddocx-org-id", "YOUR_ORGANIZATION_ID")
-            .header("origin", "https://www.turbodocx.com")
-            .header("referer", "https://www.turbodocx.com")
-            .header("accept", "application/json, text/plain, */*")
+            .header("User-Agent", "TurboDocx API Client")
             .header("Content-Type", "multipart/form-data; boundary=" + boundary)
             .POST(HttpRequest.BodyPublishers.ofByteArray(baos.toByteArray()))
             .build();

--- a/static/scripts/turbosign/api/step1-upload/java.java
+++ b/static/scripts/turbosign/api/step1-upload/java.java
@@ -6,7 +6,7 @@ public class TurboSignUpload {
     // Configuration - Update these values
     private static final String API_TOKEN = "YOUR_API_TOKEN";
     private static final String ORG_ID = "YOUR_ORGANIZATION_ID";
-    private static final String BASE_URL = "https://www.turbodocx.com/turbosign";
+    private static final String BASE_URL = "https://api.turbodocx.com";
     private static final String DOCUMENT_NAME = "Contract Agreement";
     public static void main(String[] args) throws Exception {
         // Step 1: Upload Document

--- a/static/scripts/turbosign/api/step1-upload/java.java
+++ b/static/scripts/turbosign/api/step1-upload/java.java
@@ -3,6 +3,11 @@ import java.net.http.*;
 import java.nio.file.*;
 
 public class TurboSignUpload {
+    // Configuration - Update these values
+    private static final String API_TOKEN = "YOUR_API_TOKEN";
+    private static final String ORG_ID = "YOUR_ORGANIZATION_ID";
+    private static final String BASE_URL = "https://www.turbodocx.com/turbosign";
+    private static final String DOCUMENT_NAME = "Contract Agreement";
     public static void main(String[] args) throws Exception {
         // Step 1: Upload Document
         HttpClient client = HttpClient.newHttpClient();
@@ -14,7 +19,7 @@ public class TurboSignUpload {
         StringBuilder formData = new StringBuilder();
         formData.append("--").append(boundary).append("\r\n");
         formData.append("Content-Disposition: form-data; name=\"name\"\r\n\r\n");
-        formData.append("Contract Agreement\r\n");
+        formData.append(DOCUMENT_NAME + "\r\n");
         formData.append("--").append(boundary).append("\r\n");
         formData.append("Content-Disposition: form-data; name=\"file\"; filename=\"document.pdf\"\r\n");
         formData.append("Content-Type: application/pdf\r\n\r\n");
@@ -25,9 +30,9 @@ public class TurboSignUpload {
         baos.write(("\r\n--" + boundary + "--\r\n").getBytes());
         
         HttpRequest request = HttpRequest.newBuilder()
-            .uri(URI.create("https://www.turbodocx.com/turbosign/documents/upload"))
-            .header("Authorization", "Bearer YOUR_API_TOKEN")
-            .header("x-rapiddocx-org-id", "YOUR_ORGANIZATION_ID")
+            .uri(URI.create(BASE_URL + "/documents/upload"))
+            .header("Authorization", "Bearer " + API_TOKEN)
+            .header("x-rapiddocx-org-id", ORG_ID)
             .header("User-Agent", "TurboDocx API Client")
             .header("Content-Type", "multipart/form-data; boundary=" + boundary)
             .POST(HttpRequest.BodyPublishers.ofByteArray(baos.toByteArray()))

--- a/static/scripts/turbosign/api/step1-upload/nodejs/express.js
+++ b/static/scripts/turbosign/api/step1-upload/nodejs/express.js
@@ -12,9 +12,7 @@ const response = await fetch('https://www.turbodocx.com/turbosign/documents/uplo
   headers: {
     'Authorization': 'Bearer YOUR_API_TOKEN',
     'x-rapiddocx-org-id': 'YOUR_ORGANIZATION_ID',
-    'origin': 'https://www.turbodocx.com',
-    'referer': 'https://www.turbodocx.com',
-    'accept': 'application/json, text/plain, */*',
+    'User-Agent': 'TurboDocx API Client',
     ...formData.getHeaders()
   },
   body: formData

--- a/static/scripts/turbosign/api/step1-upload/nodejs/express.js
+++ b/static/scripts/turbosign/api/step1-upload/nodejs/express.js
@@ -5,7 +5,7 @@ const fetch = require('node-fetch');
 // Configuration - Update these values
 const API_TOKEN = "YOUR_API_TOKEN";
 const ORG_ID = "YOUR_ORGANIZATION_ID";
-const BASE_URL = "https://www.turbodocx.com/turbosign";
+const BASE_URL = "https://api.turbodocx.com";
 const DOCUMENT_NAME = "Contract Agreement";
 
 // Step 1: Upload Document

--- a/static/scripts/turbosign/api/step1-upload/nodejs/express.js
+++ b/static/scripts/turbosign/api/step1-upload/nodejs/express.js
@@ -2,16 +2,22 @@ const FormData = require('form-data');
 const fs = require('fs');
 const fetch = require('node-fetch');
 
+// Configuration - Update these values
+const API_TOKEN = "YOUR_API_TOKEN";
+const ORG_ID = "YOUR_ORGANIZATION_ID";
+const BASE_URL = "https://www.turbodocx.com/turbosign";
+const DOCUMENT_NAME = "Contract Agreement";
+
 // Step 1: Upload Document
 const formData = new FormData();
-formData.append('name', 'Contract Agreement');
+formData.append('name', DOCUMENT_NAME);
 formData.append('file', fs.createReadStream('./document.pdf'));
 
-const response = await fetch('https://www.turbodocx.com/turbosign/documents/upload', {
+const response = await fetch(`${BASE_URL}/documents/upload`, {
   method: 'POST',
   headers: {
-    'Authorization': 'Bearer YOUR_API_TOKEN',
-    'x-rapiddocx-org-id': 'YOUR_ORGANIZATION_ID',
+    'Authorization': `Bearer ${API_TOKEN}`,
+    'x-rapiddocx-org-id': ORG_ID,
     'User-Agent': 'TurboDocx API Client',
     ...formData.getHeaders()
   },

--- a/static/scripts/turbosign/api/step1-upload/nodejs/fastify.js
+++ b/static/scripts/turbosign/api/step1-upload/nodejs/fastify.js
@@ -12,9 +12,7 @@ const response = await fetch('https://www.turbodocx.com/turbosign/documents/uplo
   headers: {
     'Authorization': 'Bearer YOUR_API_TOKEN',
     'x-rapiddocx-org-id': 'YOUR_ORGANIZATION_ID',
-    'origin': 'https://www.turbodocx.com',
-    'referer': 'https://www.turbodocx.com',
-    'accept': 'application/json, text/plain, */*',
+    'User-Agent': 'TurboDocx API Client',
     ...formData.getHeaders()
   },
   body: formData

--- a/static/scripts/turbosign/api/step1-upload/nodejs/fastify.js
+++ b/static/scripts/turbosign/api/step1-upload/nodejs/fastify.js
@@ -5,7 +5,7 @@ const fetch = require('node-fetch');
 // Configuration - Update these values
 const API_TOKEN = "YOUR_API_TOKEN";
 const ORG_ID = "YOUR_ORGANIZATION_ID";
-const BASE_URL = "https://www.turbodocx.com/turbosign";
+const BASE_URL = "https://api.turbodocx.com";
 const DOCUMENT_NAME = "Contract Agreement";
 
 // Step 1: Upload Document

--- a/static/scripts/turbosign/api/step1-upload/nodejs/fastify.js
+++ b/static/scripts/turbosign/api/step1-upload/nodejs/fastify.js
@@ -2,16 +2,22 @@ const FormData = require('form-data');
 const fs = require('fs');
 const fetch = require('node-fetch');
 
+// Configuration - Update these values
+const API_TOKEN = "YOUR_API_TOKEN";
+const ORG_ID = "YOUR_ORGANIZATION_ID";
+const BASE_URL = "https://www.turbodocx.com/turbosign";
+const DOCUMENT_NAME = "Contract Agreement";
+
 // Step 1: Upload Document
 const formData = new FormData();
-formData.append('name', 'Contract Agreement');
+formData.append('name', DOCUMENT_NAME);
 formData.append('file', fs.createReadStream('./document.pdf'));
 
-const response = await fetch('https://www.turbodocx.com/turbosign/documents/upload', {
+const response = await fetch(`${BASE_URL}/documents/upload`, {
   method: 'POST',
   headers: {
-    'Authorization': 'Bearer YOUR_API_TOKEN',
-    'x-rapiddocx-org-id': 'YOUR_ORGANIZATION_ID',
+    'Authorization': `Bearer ${API_TOKEN}`,
+    'x-rapiddocx-org-id': ORG_ID,
     'User-Agent': 'TurboDocx API Client',
     ...formData.getHeaders()
   },

--- a/static/scripts/turbosign/api/step1-upload/php.php
+++ b/static/scripts/turbosign/api/step1-upload/php.php
@@ -5,9 +5,7 @@ $url = 'https://www.turbodocx.com/turbosign/documents/upload';
 $headers = [
     'Authorization: Bearer YOUR_API_TOKEN',
     'x-rapiddocx-org-id: YOUR_ORGANIZATION_ID',
-    'origin: https://www.turbodocx.com',
-    'referer: https://www.turbodocx.com',
-    'accept: application/json, text/plain, */*'
+    'User-Agent: TurboDocx API Client'
 ];
 
 $postFields = [

--- a/static/scripts/turbosign/api/step1-upload/php.php
+++ b/static/scripts/turbosign/api/step1-upload/php.php
@@ -1,15 +1,21 @@
 <?php
+// Configuration - Update these values
+$API_TOKEN = "YOUR_API_TOKEN";
+$ORG_ID = "YOUR_ORGANIZATION_ID";
+$BASE_URL = "https://www.turbodocx.com/turbosign";
+$DOCUMENT_NAME = "Contract Agreement";
+
 // Step 1: Upload Document
-$url = 'https://www.turbodocx.com/turbosign/documents/upload';
+$url = $BASE_URL . '/documents/upload';
 
 $headers = [
-    'Authorization: Bearer YOUR_API_TOKEN',
-    'x-rapiddocx-org-id: YOUR_ORGANIZATION_ID',
+    'Authorization: Bearer ' . $API_TOKEN,
+    'x-rapiddocx-org-id: ' . $ORG_ID,
     'User-Agent: TurboDocx API Client'
 ];
 
 $postFields = [
-    'name' => 'Contract Agreement',
+    'name' => $DOCUMENT_NAME,
     'file' => new CURLFile('./document.pdf', 'application/pdf', 'document.pdf')
 ];
 

--- a/static/scripts/turbosign/api/step1-upload/php.php
+++ b/static/scripts/turbosign/api/step1-upload/php.php
@@ -2,7 +2,7 @@
 // Configuration - Update these values
 $API_TOKEN = "YOUR_API_TOKEN";
 $ORG_ID = "YOUR_ORGANIZATION_ID";
-$BASE_URL = "https://www.turbodocx.com/turbosign";
+$BASE_URL = "https://api.turbodocx.com";
 $DOCUMENT_NAME = "Contract Agreement";
 
 // Step 1: Upload Document

--- a/static/scripts/turbosign/api/step1-upload/powershell.ps1
+++ b/static/scripts/turbosign/api/step1-upload/powershell.ps1
@@ -25,9 +25,7 @@ $body = New-Object byte[] ($formDataBytes.Length + $fileBytes.Length + $endBound
 $headers = @{
     'Authorization' = 'Bearer YOUR_API_TOKEN'
     'x-rapiddocx-org-id' = 'YOUR_ORGANIZATION_ID'
-    'origin' = 'https://www.turbodocx.com'
-    'referer' = 'https://www.turbodocx.com'
-    'accept' = 'application/json, text/plain, */*'
+    'User-Agent' = 'TurboDocx API Client'
     'Content-Type' = "multipart/form-data; boundary=$boundary"
 }
 

--- a/static/scripts/turbosign/api/step1-upload/powershell.ps1
+++ b/static/scripts/turbosign/api/step1-upload/powershell.ps1
@@ -1,7 +1,7 @@
 # Configuration - Update these values
 $API_TOKEN = "YOUR_API_TOKEN"
 $ORG_ID = "YOUR_ORGANIZATION_ID"
-$BASE_URL = "https://www.turbodocx.com/turbosign"
+$BASE_URL = "https://api.turbodocx.com"
 $DOCUMENT_NAME = "Contract Agreement"
 
 # Step 1: Upload Document

--- a/static/scripts/turbosign/api/step1-upload/powershell.ps1
+++ b/static/scripts/turbosign/api/step1-upload/powershell.ps1
@@ -1,3 +1,9 @@
+# Configuration - Update these values
+$API_TOKEN = "YOUR_API_TOKEN"
+$ORG_ID = "YOUR_ORGANIZATION_ID"
+$BASE_URL = "https://www.turbodocx.com/turbosign"
+$DOCUMENT_NAME = "Contract Agreement"
+
 # Step 1: Upload Document
 $boundary = "----PowerShellBoundary$([System.Guid]::NewGuid())"
 $filePath = "./document.pdf"
@@ -7,7 +13,7 @@ $formData = @"
 --$boundary
 Content-Disposition: form-data; name="name"
 
-Contract Agreement
+$DOCUMENT_NAME
 --$boundary
 Content-Disposition: form-data; name="file"; filename="document.pdf"
 Content-Type: application/pdf
@@ -23,11 +29,11 @@ $body = New-Object byte[] ($formDataBytes.Length + $fileBytes.Length + $endBound
 [Array]::Copy($endBoundary, 0, $body, $formDataBytes.Length + $fileBytes.Length, $endBoundary.Length)
 
 $headers = @{
-    'Authorization' = 'Bearer YOUR_API_TOKEN'
-    'x-rapiddocx-org-id' = 'YOUR_ORGANIZATION_ID'
+    'Authorization' = "Bearer $API_TOKEN"
+    'x-rapiddocx-org-id' = $ORG_ID
     'User-Agent' = 'TurboDocx API Client'
     'Content-Type' = "multipart/form-data; boundary=$boundary"
 }
 
-$response = Invoke-RestMethod -Uri "https://www.turbodocx.com/turbosign/documents/upload" -Method Post -Body $body -Headers $headers
+$response = Invoke-RestMethod -Uri "$BASE_URL/documents/upload" -Method Post -Body $body -Headers $headers
 $response | ConvertTo-Json

--- a/static/scripts/turbosign/api/step1-upload/python/fastapi.py
+++ b/static/scripts/turbosign/api/step1-upload/python/fastapi.py
@@ -1,16 +1,22 @@
 import requests
 
+# Configuration - Update these values
+API_TOKEN = "YOUR_API_TOKEN"
+ORG_ID = "YOUR_ORGANIZATION_ID"
+BASE_URL = "https://www.turbodocx.com/turbosign"
+DOCUMENT_NAME = "Contract Agreement"
+
 # Step 1: Upload Document
 files = {
-    'name': (None, 'Contract Agreement'),
+    'name': (None, DOCUMENT_NAME),
     'file': ('document.pdf', open('document.pdf', 'rb'), 'application/pdf')
 }
 
 response = requests.post(
-    'https://www.turbodocx.com/turbosign/documents/upload',
+    f'{BASE_URL}/documents/upload',
     headers={
-        'Authorization': 'Bearer YOUR_API_TOKEN',
-        'x-rapiddocx-org-id': 'YOUR_ORGANIZATION_ID',
+        'Authorization': f'Bearer {API_TOKEN}',
+        'x-rapiddocx-org-id': ORG_ID,
         'User-Agent': 'TurboDocx API Client'
     },
     files=files

--- a/static/scripts/turbosign/api/step1-upload/python/fastapi.py
+++ b/static/scripts/turbosign/api/step1-upload/python/fastapi.py
@@ -11,9 +11,7 @@ response = requests.post(
     headers={
         'Authorization': 'Bearer YOUR_API_TOKEN',
         'x-rapiddocx-org-id': 'YOUR_ORGANIZATION_ID',
-        'origin': 'https://www.turbodocx.com',
-        'referer': 'https://www.turbodocx.com',
-        'accept': 'application/json, text/plain, */*'
+        'User-Agent': 'TurboDocx API Client'
     },
     files=files
 )

--- a/static/scripts/turbosign/api/step1-upload/python/fastapi.py
+++ b/static/scripts/turbosign/api/step1-upload/python/fastapi.py
@@ -3,7 +3,7 @@ import requests
 # Configuration - Update these values
 API_TOKEN = "YOUR_API_TOKEN"
 ORG_ID = "YOUR_ORGANIZATION_ID"
-BASE_URL = "https://www.turbodocx.com/turbosign"
+BASE_URL = "https://api.turbodocx.com"
 DOCUMENT_NAME = "Contract Agreement"
 
 # Step 1: Upload Document

--- a/static/scripts/turbosign/api/step1-upload/python/flask.py
+++ b/static/scripts/turbosign/api/step1-upload/python/flask.py
@@ -1,16 +1,22 @@
 import requests
 
+# Configuration - Update these values
+API_TOKEN = "YOUR_API_TOKEN"
+ORG_ID = "YOUR_ORGANIZATION_ID"
+BASE_URL = "https://www.turbodocx.com/turbosign"
+DOCUMENT_NAME = "Contract Agreement"
+
 # Step 1: Upload Document
 files = {
-    'name': (None, 'Contract Agreement'),
+    'name': (None, DOCUMENT_NAME),
     'file': ('document.pdf', open('document.pdf', 'rb'), 'application/pdf')
 }
 
 response = requests.post(
-    'https://www.turbodocx.com/turbosign/documents/upload',
+    f'{BASE_URL}/documents/upload',
     headers={
-        'Authorization': 'Bearer YOUR_API_TOKEN',
-        'x-rapiddocx-org-id': 'YOUR_ORGANIZATION_ID',
+        'Authorization': f'Bearer {API_TOKEN}',
+        'x-rapiddocx-org-id': ORG_ID,
         'User-Agent': 'TurboDocx API Client'
     },
     files=files

--- a/static/scripts/turbosign/api/step1-upload/python/flask.py
+++ b/static/scripts/turbosign/api/step1-upload/python/flask.py
@@ -11,9 +11,7 @@ response = requests.post(
     headers={
         'Authorization': 'Bearer YOUR_API_TOKEN',
         'x-rapiddocx-org-id': 'YOUR_ORGANIZATION_ID',
-        'origin': 'https://www.turbodocx.com',
-        'referer': 'https://www.turbodocx.com',
-        'accept': 'application/json, text/plain, */*'
+        'User-Agent': 'TurboDocx API Client'
     },
     files=files
 )

--- a/static/scripts/turbosign/api/step1-upload/python/flask.py
+++ b/static/scripts/turbosign/api/step1-upload/python/flask.py
@@ -3,7 +3,7 @@ import requests
 # Configuration - Update these values
 API_TOKEN = "YOUR_API_TOKEN"
 ORG_ID = "YOUR_ORGANIZATION_ID"
-BASE_URL = "https://www.turbodocx.com/turbosign"
+BASE_URL = "https://api.turbodocx.com"
 DOCUMENT_NAME = "Contract Agreement"
 
 # Step 1: Upload Document

--- a/static/scripts/turbosign/api/step1-upload/ruby.rb
+++ b/static/scripts/turbosign/api/step1-upload/ruby.rb
@@ -1,14 +1,20 @@
 require 'net/http'
 require 'uri'
 
+# Configuration - Update these values
+API_TOKEN = "YOUR_API_TOKEN"
+ORG_ID = "YOUR_ORGANIZATION_ID"
+BASE_URL = "https://www.turbodocx.com/turbosign"
+DOCUMENT_NAME = "Contract Agreement"
+
 # Step 1: Upload Document
-uri = URI('https://www.turbodocx.com/turbosign/documents/upload')
+uri = URI("#{BASE_URL}/documents/upload")
 boundary = "----RubyBoundary#{rand(1000000)}"
 
 form_data = ""
 form_data << "--#{boundary}\r\n"
 form_data << "Content-Disposition: form-data; name=\"name\"\r\n\r\n"
-form_data << "Contract Agreement\r\n"
+form_data << "#{DOCUMENT_NAME}\r\n"
 form_data << "--#{boundary}\r\n"
 form_data << "Content-Disposition: form-data; name=\"file\"; filename=\"document.pdf\"\r\n"
 form_data << "Content-Type: application/pdf\r\n\r\n"
@@ -19,8 +25,8 @@ http = Net::HTTP.new(uri.host, uri.port)
 http.use_ssl = true
 
 request = Net::HTTP::Post.new(uri)
-request['Authorization'] = 'Bearer YOUR_API_TOKEN'
-request['x-rapiddocx-org-id'] = 'YOUR_ORGANIZATION_ID'
+request['Authorization'] = "Bearer #{API_TOKEN}"
+request['x-rapiddocx-org-id'] = ORG_ID
 request['User-Agent'] = 'TurboDocx API Client'
 request['Content-Type'] = "multipart/form-data; boundary=#{boundary}"
 request.body = form_data

--- a/static/scripts/turbosign/api/step1-upload/ruby.rb
+++ b/static/scripts/turbosign/api/step1-upload/ruby.rb
@@ -4,7 +4,7 @@ require 'uri'
 # Configuration - Update these values
 API_TOKEN = "YOUR_API_TOKEN"
 ORG_ID = "YOUR_ORGANIZATION_ID"
-BASE_URL = "https://www.turbodocx.com/turbosign"
+BASE_URL = "https://api.turbodocx.com"
 DOCUMENT_NAME = "Contract Agreement"
 
 # Step 1: Upload Document

--- a/static/scripts/turbosign/api/step1-upload/ruby.rb
+++ b/static/scripts/turbosign/api/step1-upload/ruby.rb
@@ -21,9 +21,7 @@ http.use_ssl = true
 request = Net::HTTP::Post.new(uri)
 request['Authorization'] = 'Bearer YOUR_API_TOKEN'
 request['x-rapiddocx-org-id'] = 'YOUR_ORGANIZATION_ID'
-request['origin'] = 'https://www.turbodocx.com'
-request['referer'] = 'https://www.turbodocx.com'
-request['accept'] = 'application/json, text/plain, */*'
+request['User-Agent'] = 'TurboDocx API Client'
 request['Content-Type'] = "multipart/form-data; boundary=#{boundary}"
 request.body = form_data
 

--- a/static/scripts/turbosign/api/step2-recipients/csharp/controller.cs
+++ b/static/scripts/turbosign/api/step2-recipients/csharp/controller.cs
@@ -8,7 +8,7 @@ class Program
     // Configuration - Update these values
     private const string API_TOKEN = "YOUR_API_TOKEN";
     private const string ORG_ID = "YOUR_ORGANIZATION_ID";
-    private const string BASE_URL = "https://www.turbodocx.com/turbosign";
+    private const string BASE_URL = "https://api.turbodocx.com";
     private const string DOCUMENT_NAME = "Contract Agreement";
     static async Task Main(string[] args)
     {

--- a/static/scripts/turbosign/api/step2-recipients/csharp/controller.cs
+++ b/static/scripts/turbosign/api/step2-recipients/csharp/controller.cs
@@ -5,6 +5,11 @@ using System.Threading.Tasks;
 
 class Program
 {
+    // Configuration - Update these values
+    private const string API_TOKEN = "YOUR_API_TOKEN";
+    private const string ORG_ID = "YOUR_ORGANIZATION_ID";
+    private const string BASE_URL = "https://www.turbodocx.com/turbosign";
+    private const string DOCUMENT_NAME = "Contract Agreement";
     static async Task Main(string[] args)
     {
         // Step 2: Add Recipients
@@ -12,13 +17,13 @@ class Program
         
         using var client = new HttpClient();
         
-        client.DefaultRequestHeaders.Add("Authorization", "Bearer YOUR_API_TOKEN");
-        client.DefaultRequestHeaders.Add("x-rapiddocx-org-id", "YOUR_ORGANIZATION_ID");
+        client.DefaultRequestHeaders.Add("Authorization", "Bearer " + API_TOKEN);
+        client.DefaultRequestHeaders.Add("x-rapiddocx-org-id", ORG_ID);
         client.DefaultRequestHeaders.Add("User-Agent", "TurboDocx API Client");
         
         var payload = @"{
           ""document"": {
-            ""name"": ""Contract Agreement - Updated"",
+            ""name"": """ + DOCUMENT_NAME + " - Updated"",
             ""description"": ""This document requires electronic signatures from both parties. Please review all content carefully before signing.""
           },
           ""recipients"": [
@@ -46,7 +51,7 @@ class Program
         }";
         
         var content = new StringContent(payload, Encoding.UTF8, "application/json");
-        var response = await client.PostAsync($"https://www.turbodocx.com/turbosign/documents/{documentId}/update-with-recipients", content);
+        var response = await client.PostAsync($"{BASE_URL}/documents/{documentId}/update-with-recipients", content);
         var result = await response.Content.ReadAsStringAsync();
         
         Console.WriteLine(result);

--- a/static/scripts/turbosign/api/step2-recipients/csharp/controller.cs
+++ b/static/scripts/turbosign/api/step2-recipients/csharp/controller.cs
@@ -14,9 +14,7 @@ class Program
         
         client.DefaultRequestHeaders.Add("Authorization", "Bearer YOUR_API_TOKEN");
         client.DefaultRequestHeaders.Add("x-rapiddocx-org-id", "YOUR_ORGANIZATION_ID");
-        client.DefaultRequestHeaders.Add("origin", "https://www.turbodocx.com");
-        client.DefaultRequestHeaders.Add("referer", "https://www.turbodocx.com");
-        client.DefaultRequestHeaders.Add("accept", "application/json, text/plain, */*");
+        client.DefaultRequestHeaders.Add("User-Agent", "TurboDocx API Client");
         
         var payload = @"{
           ""document"": {

--- a/static/scripts/turbosign/api/step2-recipients/csharp/minimal.cs
+++ b/static/scripts/turbosign/api/step2-recipients/csharp/minimal.cs
@@ -8,7 +8,7 @@ class Program
     // Configuration - Update these values
     private const string API_TOKEN = "YOUR_API_TOKEN";
     private const string ORG_ID = "YOUR_ORGANIZATION_ID";
-    private const string BASE_URL = "https://www.turbodocx.com/turbosign";
+    private const string BASE_URL = "https://api.turbodocx.com";
     private const string DOCUMENT_NAME = "Contract Agreement";
     static async Task Main(string[] args)
     {

--- a/static/scripts/turbosign/api/step2-recipients/csharp/minimal.cs
+++ b/static/scripts/turbosign/api/step2-recipients/csharp/minimal.cs
@@ -5,6 +5,11 @@ using System.Threading.Tasks;
 
 class Program
 {
+    // Configuration - Update these values
+    private const string API_TOKEN = "YOUR_API_TOKEN";
+    private const string ORG_ID = "YOUR_ORGANIZATION_ID";
+    private const string BASE_URL = "https://www.turbodocx.com/turbosign";
+    private const string DOCUMENT_NAME = "Contract Agreement";
     static async Task Main(string[] args)
     {
         // Step 2: Add Recipients
@@ -12,13 +17,13 @@ class Program
         
         using var client = new HttpClient();
         
-        client.DefaultRequestHeaders.Add("Authorization", "Bearer YOUR_API_TOKEN");
-        client.DefaultRequestHeaders.Add("x-rapiddocx-org-id", "YOUR_ORGANIZATION_ID");
+        client.DefaultRequestHeaders.Add("Authorization", "Bearer " + API_TOKEN);
+        client.DefaultRequestHeaders.Add("x-rapiddocx-org-id", ORG_ID);
         client.DefaultRequestHeaders.Add("User-Agent", "TurboDocx API Client");
         
         var payload = @"{
           ""document"": {
-            ""name"": ""Contract Agreement - Updated"",
+            ""name"": """ + DOCUMENT_NAME + " - Updated"",
             ""description"": ""This document requires electronic signatures from both parties. Please review all content carefully before signing.""
           },
           ""recipients"": [
@@ -46,7 +51,7 @@ class Program
         }";
         
         var content = new StringContent(payload, Encoding.UTF8, "application/json");
-        var response = await client.PostAsync($"https://www.turbodocx.com/turbosign/documents/{documentId}/update-with-recipients", content);
+        var response = await client.PostAsync($"{BASE_URL}/documents/{documentId}/update-with-recipients", content);
         var result = await response.Content.ReadAsStringAsync();
         
         Console.WriteLine(result);

--- a/static/scripts/turbosign/api/step2-recipients/csharp/minimal.cs
+++ b/static/scripts/turbosign/api/step2-recipients/csharp/minimal.cs
@@ -14,9 +14,7 @@ class Program
         
         client.DefaultRequestHeaders.Add("Authorization", "Bearer YOUR_API_TOKEN");
         client.DefaultRequestHeaders.Add("x-rapiddocx-org-id", "YOUR_ORGANIZATION_ID");
-        client.DefaultRequestHeaders.Add("origin", "https://www.turbodocx.com");
-        client.DefaultRequestHeaders.Add("referer", "https://www.turbodocx.com");
-        client.DefaultRequestHeaders.Add("accept", "application/json, text/plain, */*");
+        client.DefaultRequestHeaders.Add("User-Agent", "TurboDocx API Client");
         
         var payload = @"{
           ""document"": {

--- a/static/scripts/turbosign/api/step2-recipients/go.go
+++ b/static/scripts/turbosign/api/step2-recipients/go.go
@@ -10,7 +10,7 @@ import (
 const (
 	API_TOKEN = "YOUR_API_TOKEN"
 	ORG_ID = "YOUR_ORGANIZATION_ID"
-	BASE_URL = "https://www.turbodocx.com/turbosign"
+	BASE_URL = "https://api.turbodocx.com"
 	DOCUMENT_NAME = "Contract Agreement"
 )
 

--- a/static/scripts/turbosign/api/step2-recipients/go.go
+++ b/static/scripts/turbosign/api/step2-recipients/go.go
@@ -6,13 +6,21 @@ import (
 	"net/http"
 )
 
+// Configuration - Update these values
+const (
+	API_TOKEN = "YOUR_API_TOKEN"
+	ORG_ID = "YOUR_ORGANIZATION_ID"
+	BASE_URL = "https://www.turbodocx.com/turbosign"
+	DOCUMENT_NAME = "Contract Agreement"
+)
+
 func main() {
 	// Step 2: Add Recipients
 	documentID := "4a20eca5-7944-430c-97d5-fcce4be24296"
 	
 	payload := `{
 	  "document": {
-		"name": "Contract Agreement - Updated",
+		"name": "` + DOCUMENT_NAME + ` - Updated",
 		"description": "This document requires electronic signatures from both parties. Please review all content carefully before signing."
 	  },
 	  "recipients": [
@@ -39,10 +47,10 @@ func main() {
 	  ]
 	}`
 	
-	req, _ := http.NewRequest("POST", fmt.Sprintf("https://www.turbodocx.com/turbosign/documents/%s/update-with-recipients", documentID), bytes.NewBufferString(payload))
+	req, _ := http.NewRequest("POST", fmt.Sprintf(BASE_URL+"/documents/%s/update-with-recipients", documentID), bytes.NewBufferString(payload))
 	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("Authorization", "Bearer YOUR_API_TOKEN")
-	req.Header.Set("x-rapiddocx-org-id", "YOUR_ORGANIZATION_ID")
+	req.Header.Set("Authorization", "Bearer "+API_TOKEN)
+	req.Header.Set("x-rapiddocx-org-id", ORG_ID)
 	req.Header.Set("User-Agent", "TurboDocx API Client")
 	
 	client := &http.Client{}

--- a/static/scripts/turbosign/api/step2-recipients/go.go
+++ b/static/scripts/turbosign/api/step2-recipients/go.go
@@ -43,9 +43,7 @@ func main() {
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Authorization", "Bearer YOUR_API_TOKEN")
 	req.Header.Set("x-rapiddocx-org-id", "YOUR_ORGANIZATION_ID")
-	req.Header.Set("origin", "https://www.turbodocx.com")
-	req.Header.Set("referer", "https://www.turbodocx.com")
-	req.Header.Set("accept", "application/json, text/plain, */*")
+	req.Header.Set("User-Agent", "TurboDocx API Client")
 	
 	client := &http.Client{}
 	resp, _ := client.Do(req)

--- a/static/scripts/turbosign/api/step2-recipients/java.java
+++ b/static/scripts/turbosign/api/step2-recipients/java.java
@@ -2,6 +2,11 @@ import java.net.http.*;
 import java.net.URI;
 
 public class TurboSignRecipients {
+    // Configuration - Update these values
+    private static final String API_TOKEN = "YOUR_API_TOKEN";
+    private static final String ORG_ID = "YOUR_ORGANIZATION_ID";
+    private static final String BASE_URL = "https://www.turbodocx.com/turbosign";
+    private static final String DOCUMENT_NAME = "Contract Agreement";
     public static void main(String[] args) throws Exception {
         // Step 2: Add Recipients
         String documentId = "4a20eca5-7944-430c-97d5-fcce4be24296";
@@ -11,7 +16,7 @@ public class TurboSignRecipients {
         String payload = """
         {
           "document": {
-            "name": "Contract Agreement - Updated",
+            "name": "" + DOCUMENT_NAME + " - Updated",
             "description": "This document requires electronic signatures from both parties. Please review all content carefully before signing."
           },
           "recipients": [
@@ -40,10 +45,10 @@ public class TurboSignRecipients {
         """.formatted(documentId, documentId);
         
         HttpRequest request = HttpRequest.newBuilder()
-            .uri(URI.create("https://www.turbodocx.com/turbosign/documents/" + documentId + "/update-with-recipients"))
+            .uri(URI.create(BASE_URL + "/documents/" + documentId + "/update-with-recipients"))
             .header("Content-Type", "application/json")
-            .header("Authorization", "Bearer YOUR_API_TOKEN")
-            .header("x-rapiddocx-org-id", "YOUR_ORGANIZATION_ID")
+            .header("Authorization", "Bearer " + API_TOKEN)
+            .header("x-rapiddocx-org-id", ORG_ID)
             .header("User-Agent", "TurboDocx API Client")
             .POST(HttpRequest.BodyPublishers.ofString(payload))
             .build();

--- a/static/scripts/turbosign/api/step2-recipients/java.java
+++ b/static/scripts/turbosign/api/step2-recipients/java.java
@@ -44,9 +44,7 @@ public class TurboSignRecipients {
             .header("Content-Type", "application/json")
             .header("Authorization", "Bearer YOUR_API_TOKEN")
             .header("x-rapiddocx-org-id", "YOUR_ORGANIZATION_ID")
-            .header("origin", "https://www.turbodocx.com")
-            .header("referer", "https://www.turbodocx.com")
-            .header("accept", "application/json, text/plain, */*")
+            .header("User-Agent", "TurboDocx API Client")
             .POST(HttpRequest.BodyPublishers.ofString(payload))
             .build();
         

--- a/static/scripts/turbosign/api/step2-recipients/java.java
+++ b/static/scripts/turbosign/api/step2-recipients/java.java
@@ -5,7 +5,7 @@ public class TurboSignRecipients {
     // Configuration - Update these values
     private static final String API_TOKEN = "YOUR_API_TOKEN";
     private static final String ORG_ID = "YOUR_ORGANIZATION_ID";
-    private static final String BASE_URL = "https://www.turbodocx.com/turbosign";
+    private static final String BASE_URL = "https://api.turbodocx.com";
     private static final String DOCUMENT_NAME = "Contract Agreement";
     public static void main(String[] args) throws Exception {
         // Step 2: Add Recipients

--- a/static/scripts/turbosign/api/step2-recipients/nodejs/express.js
+++ b/static/scripts/turbosign/api/step2-recipients/nodejs/express.js
@@ -1,11 +1,17 @@
 const fetch = require('node-fetch');
 
+// Configuration - Update these values
+const API_TOKEN = "YOUR_API_TOKEN";
+const ORG_ID = "YOUR_ORGANIZATION_ID";
+const BASE_URL = "https://www.turbodocx.com/turbosign";
+const DOCUMENT_NAME = "Contract Agreement";
+
 // Step 2: Add Recipients
 const documentId = "4a20eca5-7944-430c-97d5-fcce4be24296";
 
 const payload = {
   "document": {
-    "name": "Contract Agreement - Updated",
+    "name": `${DOCUMENT_NAME} - Updated`,
     "description": "This document requires electronic signatures from both parties. Please review all content carefully before signing."
   },
   "recipients": [
@@ -32,12 +38,12 @@ const payload = {
   ]
 };
 
-const response = await fetch(`https://www.turbodocx.com/turbosign/documents/${documentId}/update-with-recipients`, {
+const response = await fetch(`${BASE_URL}/documents/${documentId}/update-with-recipients`, {
   method: 'POST',
   headers: {
     'Content-Type': 'application/json',
-    'Authorization': 'Bearer YOUR_API_TOKEN',
-    'x-rapiddocx-org-id': 'YOUR_ORGANIZATION_ID',
+    'Authorization': `Bearer ${API_TOKEN}`,
+    'x-rapiddocx-org-id': ORG_ID,
     'User-Agent': 'TurboDocx API Client'
   },
   body: JSON.stringify(payload)

--- a/static/scripts/turbosign/api/step2-recipients/nodejs/express.js
+++ b/static/scripts/turbosign/api/step2-recipients/nodejs/express.js
@@ -3,7 +3,7 @@ const fetch = require('node-fetch');
 // Configuration - Update these values
 const API_TOKEN = "YOUR_API_TOKEN";
 const ORG_ID = "YOUR_ORGANIZATION_ID";
-const BASE_URL = "https://www.turbodocx.com/turbosign";
+const BASE_URL = "https://api.turbodocx.com";
 const DOCUMENT_NAME = "Contract Agreement";
 
 // Step 2: Add Recipients

--- a/static/scripts/turbosign/api/step2-recipients/nodejs/express.js
+++ b/static/scripts/turbosign/api/step2-recipients/nodejs/express.js
@@ -38,12 +38,7 @@ const response = await fetch(`https://www.turbodocx.com/turbosign/documents/${do
     'Content-Type': 'application/json',
     'Authorization': 'Bearer YOUR_API_TOKEN',
     'x-rapiddocx-org-id': 'YOUR_ORGANIZATION_ID',
-    'origin': 'https://www.turbodocx.com',
-    'referer': 'https://www.turbodocx.com',
-    'accept': 'application/json, text/plain, */*',
-    'dnt': '1',
-    'accept-language': 'en-US,en;q=0.9',
-    'priority': 'u=1, i'
+    'User-Agent': 'TurboDocx API Client'
   },
   body: JSON.stringify(payload)
 });

--- a/static/scripts/turbosign/api/step2-recipients/nodejs/fastify.js
+++ b/static/scripts/turbosign/api/step2-recipients/nodejs/fastify.js
@@ -1,11 +1,17 @@
 const fetch = require('node-fetch');
 
+// Configuration - Update these values
+const API_TOKEN = "YOUR_API_TOKEN";
+const ORG_ID = "YOUR_ORGANIZATION_ID";
+const BASE_URL = "https://www.turbodocx.com/turbosign";
+const DOCUMENT_NAME = "Contract Agreement";
+
 // Step 2: Add Recipients
 const documentId = "4a20eca5-7944-430c-97d5-fcce4be24296";
 
 const payload = {
   "document": {
-    "name": "Contract Agreement - Updated",
+    "name": `${DOCUMENT_NAME} - Updated`,
     "description": "This document requires electronic signatures from both parties. Please review all content carefully before signing."
   },
   "recipients": [
@@ -32,12 +38,12 @@ const payload = {
   ]
 };
 
-const response = await fetch(`https://www.turbodocx.com/turbosign/documents/${documentId}/update-with-recipients`, {
+const response = await fetch(`${BASE_URL}/documents/${documentId}/update-with-recipients`, {
   method: 'POST',
   headers: {
     'Content-Type': 'application/json',
-    'Authorization': 'Bearer YOUR_API_TOKEN',
-    'x-rapiddocx-org-id': 'YOUR_ORGANIZATION_ID',
+    'Authorization': `Bearer ${API_TOKEN}`,
+    'x-rapiddocx-org-id': ORG_ID,
     'User-Agent': 'TurboDocx API Client'
   },
   body: JSON.stringify(payload)

--- a/static/scripts/turbosign/api/step2-recipients/nodejs/fastify.js
+++ b/static/scripts/turbosign/api/step2-recipients/nodejs/fastify.js
@@ -3,7 +3,7 @@ const fetch = require('node-fetch');
 // Configuration - Update these values
 const API_TOKEN = "YOUR_API_TOKEN";
 const ORG_ID = "YOUR_ORGANIZATION_ID";
-const BASE_URL = "https://www.turbodocx.com/turbosign";
+const BASE_URL = "https://api.turbodocx.com";
 const DOCUMENT_NAME = "Contract Agreement";
 
 // Step 2: Add Recipients

--- a/static/scripts/turbosign/api/step2-recipients/nodejs/fastify.js
+++ b/static/scripts/turbosign/api/step2-recipients/nodejs/fastify.js
@@ -38,12 +38,7 @@ const response = await fetch(`https://www.turbodocx.com/turbosign/documents/${do
     'Content-Type': 'application/json',
     'Authorization': 'Bearer YOUR_API_TOKEN',
     'x-rapiddocx-org-id': 'YOUR_ORGANIZATION_ID',
-    'origin': 'https://www.turbodocx.com',
-    'referer': 'https://www.turbodocx.com',
-    'accept': 'application/json, text/plain, */*',
-    'dnt': '1',
-    'accept-language': 'en-US,en;q=0.9',
-    'priority': 'u=1, i'
+    'User-Agent': 'TurboDocx API Client'
   },
   body: JSON.stringify(payload)
 });

--- a/static/scripts/turbosign/api/step2-recipients/php.php
+++ b/static/scripts/turbosign/api/step2-recipients/php.php
@@ -2,7 +2,7 @@
 // Configuration - Update these values
 $API_TOKEN = "YOUR_API_TOKEN";
 $ORG_ID = "YOUR_ORGANIZATION_ID";
-$BASE_URL = "https://www.turbodocx.com/turbosign";
+$BASE_URL = "https://api.turbodocx.com";
 $DOCUMENT_NAME = "Contract Agreement";
 
 // Step 2: Add Recipients

--- a/static/scripts/turbosign/api/step2-recipients/php.php
+++ b/static/scripts/turbosign/api/step2-recipients/php.php
@@ -8,12 +8,7 @@ $headers = [
     'Content-Type: application/json',
     'Authorization: Bearer YOUR_API_TOKEN',
     'x-rapiddocx-org-id: YOUR_ORGANIZATION_ID',
-    'origin: https://www.turbodocx.com',
-    'referer: https://www.turbodocx.com',
-    'accept: application/json, text/plain, */*',
-    'dnt: 1',
-    'accept-language: en-US,en;q=0.9',
-    'priority: u=1, i'
+    'User-Agent: TurboDocx API Client'
 ];
 
 $payload = [

--- a/static/scripts/turbosign/api/step2-recipients/php.php
+++ b/static/scripts/turbosign/api/step2-recipients/php.php
@@ -1,19 +1,25 @@
 <?php
+// Configuration - Update these values
+$API_TOKEN = "YOUR_API_TOKEN";
+$ORG_ID = "YOUR_ORGANIZATION_ID";
+$BASE_URL = "https://www.turbodocx.com/turbosign";
+$DOCUMENT_NAME = "Contract Agreement";
+
 // Step 2: Add Recipients
 $document_id = "4a20eca5-7944-430c-97d5-fcce4be24296";
 
-$url = "https://www.turbodocx.com/turbosign/documents/$document_id/update-with-recipients";
+$url = $BASE_URL . "/documents/$document_id/update-with-recipients";
 
 $headers = [
     'Content-Type: application/json',
-    'Authorization: Bearer YOUR_API_TOKEN',
-    'x-rapiddocx-org-id: YOUR_ORGANIZATION_ID',
+    'Authorization: Bearer ' . $API_TOKEN,
+    'x-rapiddocx-org-id: ' . $ORG_ID,
     'User-Agent: TurboDocx API Client'
 ];
 
 $payload = [
     'document' => [
-        'name' => 'Contract Agreement - Updated',
+        'name' => $DOCUMENT_NAME . ' - Updated',
         'description' => 'This document requires electronic signatures from both parties. Please review all content carefully before signing.'
     ],
     'recipients' => [

--- a/static/scripts/turbosign/api/step2-recipients/powershell.ps1
+++ b/static/scripts/turbosign/api/step2-recipients/powershell.ps1
@@ -1,9 +1,15 @@
+# Configuration - Update these values
+$API_TOKEN = "YOUR_API_TOKEN"
+$ORG_ID = "YOUR_ORGANIZATION_ID"
+$BASE_URL = "https://www.turbodocx.com/turbosign"
+$DOCUMENT_NAME = "Contract Agreement"
+
 # Step 2: Add Recipients
 $documentId = "4a20eca5-7944-430c-97d5-fcce4be24296"
 
 $payload = @{
     document = @{
-        name = "Contract Agreement - Updated"
+        name = "$DOCUMENT_NAME - Updated"
         description = "This document requires electronic signatures from both parties. Please review all content carefully before signing."
     }
     recipients = @(
@@ -32,10 +38,10 @@ $payload = @{
 
 $headers = @{
     'Content-Type' = 'application/json'
-    'Authorization' = 'Bearer YOUR_API_TOKEN'
-    'x-rapiddocx-org-id' = 'YOUR_ORGANIZATION_ID'
+    'Authorization' = "Bearer $API_TOKEN"
+    'x-rapiddocx-org-id' = $ORG_ID
     'User-Agent' = 'TurboDocx API Client'
 }
 
-$response = Invoke-RestMethod -Uri "https://www.turbodocx.com/turbosign/documents/$documentId/update-with-recipients" -Method Post -Body $payload -Headers $headers -ContentType 'application/json'
+$response = Invoke-RestMethod -Uri "$BASE_URL/documents/$documentId/update-with-recipients" -Method Post -Body $payload -Headers $headers -ContentType 'application/json'
 $response | ConvertTo-Json

--- a/static/scripts/turbosign/api/step2-recipients/powershell.ps1
+++ b/static/scripts/turbosign/api/step2-recipients/powershell.ps1
@@ -1,7 +1,7 @@
 # Configuration - Update these values
 $API_TOKEN = "YOUR_API_TOKEN"
 $ORG_ID = "YOUR_ORGANIZATION_ID"
-$BASE_URL = "https://www.turbodocx.com/turbosign"
+$BASE_URL = "https://api.turbodocx.com"
 $DOCUMENT_NAME = "Contract Agreement"
 
 # Step 2: Add Recipients

--- a/static/scripts/turbosign/api/step2-recipients/powershell.ps1
+++ b/static/scripts/turbosign/api/step2-recipients/powershell.ps1
@@ -34,9 +34,7 @@ $headers = @{
     'Content-Type' = 'application/json'
     'Authorization' = 'Bearer YOUR_API_TOKEN'
     'x-rapiddocx-org-id' = 'YOUR_ORGANIZATION_ID'
-    'origin' = 'https://www.turbodocx.com'
-    'referer' = 'https://www.turbodocx.com'
-    'accept' = 'application/json, text/plain, */*'
+    'User-Agent' = 'TurboDocx API Client'
 }
 
 $response = Invoke-RestMethod -Uri "https://www.turbodocx.com/turbosign/documents/$documentId/update-with-recipients" -Method Post -Body $payload -Headers $headers -ContentType 'application/json'

--- a/static/scripts/turbosign/api/step2-recipients/python/fastapi.py
+++ b/static/scripts/turbosign/api/step2-recipients/python/fastapi.py
@@ -10,12 +10,7 @@ headers = {
     "Content-Type": "application/json",
     "Authorization": "Bearer YOUR_API_TOKEN",
     "x-rapiddocx-org-id": "YOUR_ORGANIZATION_ID",
-    "origin": "https://www.turbodocx.com",
-    "referer": "https://www.turbodocx.com",
-    "accept": "application/json, text/plain, */*",
-    "dnt": "1",
-    "accept-language": "en-US,en;q=0.9",
-    "priority": "u=1, i"
+    "User-Agent": "TurboDocx API Client"
 }
 
 payload = {

--- a/static/scripts/turbosign/api/step2-recipients/python/fastapi.py
+++ b/static/scripts/turbosign/api/step2-recipients/python/fastapi.py
@@ -1,21 +1,27 @@
 import requests
 import json
 
+# Configuration - Update these values
+API_TOKEN = "YOUR_API_TOKEN"
+ORG_ID = "YOUR_ORGANIZATION_ID"
+BASE_URL = "https://www.turbodocx.com/turbosign"
+DOCUMENT_NAME = "Contract Agreement"
+
 # Step 2: Add Recipients
 document_id = "4a20eca5-7944-430c-97d5-fcce4be24296"
 
-url = f"https://www.turbodocx.com/turbosign/documents/{document_id}/update-with-recipients"
+url = f"{BASE_URL}/documents/{document_id}/update-with-recipients"
 
 headers = {
     "Content-Type": "application/json",
-    "Authorization": "Bearer YOUR_API_TOKEN",
-    "x-rapiddocx-org-id": "YOUR_ORGANIZATION_ID",
+    "Authorization": f"Bearer {API_TOKEN}",
+    "x-rapiddocx-org-id": ORG_ID,
     "User-Agent": "TurboDocx API Client"
 }
 
 payload = {
     "document": {
-        "name": "Contract Agreement - Updated",
+        "name": f"{DOCUMENT_NAME} - Updated",
         "description": "This document requires electronic signatures from both parties. Please review all content carefully before signing."
     },
     "recipients": [

--- a/static/scripts/turbosign/api/step2-recipients/python/fastapi.py
+++ b/static/scripts/turbosign/api/step2-recipients/python/fastapi.py
@@ -4,7 +4,7 @@ import json
 # Configuration - Update these values
 API_TOKEN = "YOUR_API_TOKEN"
 ORG_ID = "YOUR_ORGANIZATION_ID"
-BASE_URL = "https://www.turbodocx.com/turbosign"
+BASE_URL = "https://api.turbodocx.com"
 DOCUMENT_NAME = "Contract Agreement"
 
 # Step 2: Add Recipients

--- a/static/scripts/turbosign/api/step2-recipients/python/flask.py
+++ b/static/scripts/turbosign/api/step2-recipients/python/flask.py
@@ -10,12 +10,7 @@ headers = {
     "Content-Type": "application/json",
     "Authorization": "Bearer YOUR_API_TOKEN",
     "x-rapiddocx-org-id": "YOUR_ORGANIZATION_ID",
-    "origin": "https://www.turbodocx.com",
-    "referer": "https://www.turbodocx.com",
-    "accept": "application/json, text/plain, */*",
-    "dnt": "1",
-    "accept-language": "en-US,en;q=0.9",
-    "priority": "u=1, i"
+    "User-Agent": "TurboDocx API Client"
 }
 
 payload = {

--- a/static/scripts/turbosign/api/step2-recipients/python/flask.py
+++ b/static/scripts/turbosign/api/step2-recipients/python/flask.py
@@ -1,21 +1,27 @@
 import requests
 import json
 
+# Configuration - Update these values
+API_TOKEN = "YOUR_API_TOKEN"
+ORG_ID = "YOUR_ORGANIZATION_ID"
+BASE_URL = "https://www.turbodocx.com/turbosign"
+DOCUMENT_NAME = "Contract Agreement"
+
 # Step 2: Add Recipients
 document_id = "4a20eca5-7944-430c-97d5-fcce4be24296"
 
-url = f"https://www.turbodocx.com/turbosign/documents/{document_id}/update-with-recipients"
+url = f"{BASE_URL}/documents/{document_id}/update-with-recipients"
 
 headers = {
     "Content-Type": "application/json",
-    "Authorization": "Bearer YOUR_API_TOKEN",
-    "x-rapiddocx-org-id": "YOUR_ORGANIZATION_ID",
+    "Authorization": f"Bearer {API_TOKEN}",
+    "x-rapiddocx-org-id": ORG_ID,
     "User-Agent": "TurboDocx API Client"
 }
 
 payload = {
     "document": {
-        "name": "Contract Agreement - Updated",
+        "name": f"{DOCUMENT_NAME} - Updated",
         "description": "This document requires electronic signatures from both parties. Please review all content carefully before signing."
     },
     "recipients": [

--- a/static/scripts/turbosign/api/step2-recipients/python/flask.py
+++ b/static/scripts/turbosign/api/step2-recipients/python/flask.py
@@ -4,7 +4,7 @@ import json
 # Configuration - Update these values
 API_TOKEN = "YOUR_API_TOKEN"
 ORG_ID = "YOUR_ORGANIZATION_ID"
-BASE_URL = "https://www.turbodocx.com/turbosign"
+BASE_URL = "https://api.turbodocx.com"
 DOCUMENT_NAME = "Contract Agreement"
 
 # Step 2: Add Recipients

--- a/static/scripts/turbosign/api/step2-recipients/ruby.rb
+++ b/static/scripts/turbosign/api/step2-recipients/ruby.rb
@@ -5,7 +5,7 @@ require 'json'
 # Configuration - Update these values
 API_TOKEN = "YOUR_API_TOKEN"
 ORG_ID = "YOUR_ORGANIZATION_ID"
-BASE_URL = "https://www.turbodocx.com/turbosign"
+BASE_URL = "https://api.turbodocx.com"
 DOCUMENT_NAME = "Contract Agreement"
 
 # Step 2: Add Recipients

--- a/static/scripts/turbosign/api/step2-recipients/ruby.rb
+++ b/static/scripts/turbosign/api/step2-recipients/ruby.rb
@@ -43,9 +43,7 @@ request = Net::HTTP::Post.new(uri)
 request['Content-Type'] = 'application/json'
 request['Authorization'] = 'Bearer YOUR_API_TOKEN'
 request['x-rapiddocx-org-id'] = 'YOUR_ORGANIZATION_ID'
-request['origin'] = 'https://www.turbodocx.com'
-request['referer'] = 'https://www.turbodocx.com'
-request['accept'] = 'application/json, text/plain, */*'
+request['User-Agent'] = 'TurboDocx API Client'
 request.body = payload.to_json
 
 response = http.request(request)

--- a/static/scripts/turbosign/api/step2-recipients/ruby.rb
+++ b/static/scripts/turbosign/api/step2-recipients/ruby.rb
@@ -2,12 +2,18 @@ require 'net/http'
 require 'uri'
 require 'json'
 
+# Configuration - Update these values
+API_TOKEN = "YOUR_API_TOKEN"
+ORG_ID = "YOUR_ORGANIZATION_ID"
+BASE_URL = "https://www.turbodocx.com/turbosign"
+DOCUMENT_NAME = "Contract Agreement"
+
 # Step 2: Add Recipients
 document_id = "4a20eca5-7944-430c-97d5-fcce4be24296"
 
 payload = {
   "document" => {
-    "name" => "Contract Agreement - Updated",
+    "name" => "#{DOCUMENT_NAME} - Updated",
     "description" => "This document requires electronic signatures from both parties. Please review all content carefully before signing."
   },
   "recipients" => [
@@ -34,15 +40,15 @@ payload = {
   ]
 }
 
-uri = URI("https://www.turbodocx.com/turbosign/documents/#{document_id}/update-with-recipients")
+uri = URI("#{BASE_URL}/documents/#{document_id}/update-with-recipients")
 
 http = Net::HTTP.new(uri.host, uri.port)
 http.use_ssl = true
 
 request = Net::HTTP::Post.new(uri)
 request['Content-Type'] = 'application/json'
-request['Authorization'] = 'Bearer YOUR_API_TOKEN'
-request['x-rapiddocx-org-id'] = 'YOUR_ORGANIZATION_ID'
+request['Authorization'] = "Bearer #{API_TOKEN}"
+request['x-rapiddocx-org-id'] = ORG_ID
 request['User-Agent'] = 'TurboDocx API Client'
 request.body = payload.to_json
 

--- a/static/scripts/turbosign/api/step3-prepare/csharp/controller.cs
+++ b/static/scripts/turbosign/api/step3-prepare/csharp/controller.cs
@@ -8,7 +8,7 @@ class Program
     // Configuration - Update these values
     private const string API_TOKEN = "YOUR_API_TOKEN";
     private const string ORG_ID = "YOUR_ORGANIZATION_ID";
-    private const string BASE_URL = "https://www.turbodocx.com/turbosign";
+    private const string BASE_URL = "https://api.turbodocx.com";
     private const string DOCUMENT_NAME = "Contract Agreement";
     static async Task Main(string[] args)
     {

--- a/static/scripts/turbosign/api/step3-prepare/csharp/controller.cs
+++ b/static/scripts/turbosign/api/step3-prepare/csharp/controller.cs
@@ -14,9 +14,7 @@ class Program
         
         client.DefaultRequestHeaders.Add("Authorization", "Bearer YOUR_API_TOKEN");
         client.DefaultRequestHeaders.Add("x-rapiddocx-org-id", "YOUR_ORGANIZATION_ID");
-        client.DefaultRequestHeaders.Add("origin", "https://www.turbodocx.com");
-        client.DefaultRequestHeaders.Add("referer", "https://www.turbodocx.com");
-        client.DefaultRequestHeaders.Add("accept", "application/json, text/plain, */*");
+        client.DefaultRequestHeaders.Add("User-Agent", "TurboDocx API Client");
         
         var payload = @"[
           {

--- a/static/scripts/turbosign/api/step3-prepare/csharp/controller.cs
+++ b/static/scripts/turbosign/api/step3-prepare/csharp/controller.cs
@@ -5,6 +5,11 @@ using System.Threading.Tasks;
 
 class Program
 {
+    // Configuration - Update these values
+    private const string API_TOKEN = "YOUR_API_TOKEN";
+    private const string ORG_ID = "YOUR_ORGANIZATION_ID";
+    private const string BASE_URL = "https://www.turbodocx.com/turbosign";
+    private const string DOCUMENT_NAME = "Contract Agreement";
     static async Task Main(string[] args)
     {
         // Step 3: Prepare for Signing
@@ -12,8 +17,8 @@ class Program
         
         using var client = new HttpClient();
         
-        client.DefaultRequestHeaders.Add("Authorization", "Bearer YOUR_API_TOKEN");
-        client.DefaultRequestHeaders.Add("x-rapiddocx-org-id", "YOUR_ORGANIZATION_ID");
+        client.DefaultRequestHeaders.Add("Authorization", "Bearer " + API_TOKEN);
+        client.DefaultRequestHeaders.Add("x-rapiddocx-org-id", ORG_ID);
         client.DefaultRequestHeaders.Add("User-Agent", "TurboDocx API Client");
         
         var payload = @"[
@@ -76,7 +81,7 @@ class Program
         ]";
         
         var content = new StringContent(payload, Encoding.UTF8, "application/json");
-        var response = await client.PostAsync($"https://www.turbodocx.com/turbosign/documents/{documentId}/prepare-for-signing", content);
+        var response = await client.PostAsync($"{BASE_URL}/documents/{documentId}/prepare-for-signing", content);
         var result = await response.Content.ReadAsStringAsync();
         
         Console.WriteLine(result);

--- a/static/scripts/turbosign/api/step3-prepare/csharp/minimal.cs
+++ b/static/scripts/turbosign/api/step3-prepare/csharp/minimal.cs
@@ -8,7 +8,7 @@ class Program
     // Configuration - Update these values
     private const string API_TOKEN = "YOUR_API_TOKEN";
     private const string ORG_ID = "YOUR_ORGANIZATION_ID";
-    private const string BASE_URL = "https://www.turbodocx.com/turbosign";
+    private const string BASE_URL = "https://api.turbodocx.com";
     private const string DOCUMENT_NAME = "Contract Agreement";
     static async Task Main(string[] args)
     {

--- a/static/scripts/turbosign/api/step3-prepare/csharp/minimal.cs
+++ b/static/scripts/turbosign/api/step3-prepare/csharp/minimal.cs
@@ -14,9 +14,7 @@ class Program
         
         client.DefaultRequestHeaders.Add("Authorization", "Bearer YOUR_API_TOKEN");
         client.DefaultRequestHeaders.Add("x-rapiddocx-org-id", "YOUR_ORGANIZATION_ID");
-        client.DefaultRequestHeaders.Add("origin", "https://www.turbodocx.com");
-        client.DefaultRequestHeaders.Add("referer", "https://www.turbodocx.com");
-        client.DefaultRequestHeaders.Add("accept", "application/json, text/plain, */*");
+        client.DefaultRequestHeaders.Add("User-Agent", "TurboDocx API Client");
         
         var payload = @"[
           {

--- a/static/scripts/turbosign/api/step3-prepare/csharp/minimal.cs
+++ b/static/scripts/turbosign/api/step3-prepare/csharp/minimal.cs
@@ -5,6 +5,11 @@ using System.Threading.Tasks;
 
 class Program
 {
+    // Configuration - Update these values
+    private const string API_TOKEN = "YOUR_API_TOKEN";
+    private const string ORG_ID = "YOUR_ORGANIZATION_ID";
+    private const string BASE_URL = "https://www.turbodocx.com/turbosign";
+    private const string DOCUMENT_NAME = "Contract Agreement";
     static async Task Main(string[] args)
     {
         // Step 3: Prepare for Signing
@@ -12,8 +17,8 @@ class Program
         
         using var client = new HttpClient();
         
-        client.DefaultRequestHeaders.Add("Authorization", "Bearer YOUR_API_TOKEN");
-        client.DefaultRequestHeaders.Add("x-rapiddocx-org-id", "YOUR_ORGANIZATION_ID");
+        client.DefaultRequestHeaders.Add("Authorization", "Bearer " + API_TOKEN);
+        client.DefaultRequestHeaders.Add("x-rapiddocx-org-id", ORG_ID);
         client.DefaultRequestHeaders.Add("User-Agent", "TurboDocx API Client");
         
         var payload = @"[
@@ -76,7 +81,7 @@ class Program
         ]";
         
         var content = new StringContent(payload, Encoding.UTF8, "application/json");
-        var response = await client.PostAsync($"https://www.turbodocx.com/turbosign/documents/{documentId}/prepare-for-signing", content);
+        var response = await client.PostAsync($"{BASE_URL}/documents/{documentId}/prepare-for-signing", content);
         var result = await response.Content.ReadAsStringAsync();
         
         Console.WriteLine(result);

--- a/static/scripts/turbosign/api/step3-prepare/go.go
+++ b/static/scripts/turbosign/api/step3-prepare/go.go
@@ -6,6 +6,13 @@ import (
 	"net/http"
 )
 
+// Configuration - Update these values
+const (
+	API_TOKEN = "YOUR_API_TOKEN"
+	ORG_ID = "YOUR_ORGANIZATION_ID"
+	BASE_URL = "https://www.turbodocx.com/turbosign"
+)
+
 func main() {
 	// Step 3: Prepare for Signing
 	documentID := "4a20eca5-7944-430c-97d5-fcce4be24296"
@@ -69,10 +76,10 @@ func main() {
 	  }
 	]`
 	
-	req, _ := http.NewRequest("POST", fmt.Sprintf("https://www.turbodocx.com/turbosign/documents/%s/prepare-for-signing", documentID), bytes.NewBufferString(payload))
+	req, _ := http.NewRequest("POST", fmt.Sprintf(BASE_URL+"/documents/%s/prepare-for-signing", documentID), bytes.NewBufferString(payload))
 	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("Authorization", "Bearer YOUR_API_TOKEN")
-	req.Header.Set("x-rapiddocx-org-id", "YOUR_ORGANIZATION_ID")
+	req.Header.Set("Authorization", "Bearer "+API_TOKEN)
+	req.Header.Set("x-rapiddocx-org-id", ORG_ID)
 	req.Header.Set("User-Agent", "TurboDocx API Client")
 	
 	client := &http.Client{}

--- a/static/scripts/turbosign/api/step3-prepare/go.go
+++ b/static/scripts/turbosign/api/step3-prepare/go.go
@@ -11,6 +11,7 @@ const (
 	API_TOKEN = "YOUR_API_TOKEN"
 	ORG_ID = "YOUR_ORGANIZATION_ID"
 	BASE_URL = "https://api.turbodocx.com"
+	DOCUMENT_NAME = "Contract Agreement"
 )
 
 func main() {

--- a/static/scripts/turbosign/api/step3-prepare/go.go
+++ b/static/scripts/turbosign/api/step3-prepare/go.go
@@ -10,7 +10,7 @@ import (
 const (
 	API_TOKEN = "YOUR_API_TOKEN"
 	ORG_ID = "YOUR_ORGANIZATION_ID"
-	BASE_URL = "https://www.turbodocx.com/turbosign"
+	BASE_URL = "https://api.turbodocx.com"
 )
 
 func main() {

--- a/static/scripts/turbosign/api/step3-prepare/go.go
+++ b/static/scripts/turbosign/api/step3-prepare/go.go
@@ -73,9 +73,7 @@ func main() {
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Authorization", "Bearer YOUR_API_TOKEN")
 	req.Header.Set("x-rapiddocx-org-id", "YOUR_ORGANIZATION_ID")
-	req.Header.Set("origin", "https://www.turbodocx.com")
-	req.Header.Set("referer", "https://www.turbodocx.com")
-	req.Header.Set("accept", "application/json, text/plain, */*")
+	req.Header.Set("User-Agent", "TurboDocx API Client")
 	
 	client := &http.Client{}
 	resp, _ := client.Do(req)

--- a/static/scripts/turbosign/api/step3-prepare/java.java
+++ b/static/scripts/turbosign/api/step3-prepare/java.java
@@ -5,7 +5,7 @@ public class TurboSignPrepare {
     // Configuration - Update these values
     private static final String API_TOKEN = "YOUR_API_TOKEN";
     private static final String ORG_ID = "YOUR_ORGANIZATION_ID";
-    private static final String BASE_URL = "https://www.turbodocx.com/turbosign";
+    private static final String BASE_URL = "https://api.turbodocx.com";
     private static final String DOCUMENT_NAME = "Contract Agreement";
     public static void main(String[] args) throws Exception {
         // Step 3: Prepare for Signing

--- a/static/scripts/turbosign/api/step3-prepare/java.java
+++ b/static/scripts/turbosign/api/step3-prepare/java.java
@@ -74,9 +74,7 @@ public class TurboSignPrepare {
             .header("Content-Type", "application/json")
             .header("Authorization", "Bearer YOUR_API_TOKEN")
             .header("x-rapiddocx-org-id", "YOUR_ORGANIZATION_ID")
-            .header("origin", "https://www.turbodocx.com")
-            .header("referer", "https://www.turbodocx.com")
-            .header("accept", "application/json, text/plain, */*")
+            .header("User-Agent", "TurboDocx API Client")
             .POST(HttpRequest.BodyPublishers.ofString(payload))
             .build();
         

--- a/static/scripts/turbosign/api/step3-prepare/java.java
+++ b/static/scripts/turbosign/api/step3-prepare/java.java
@@ -2,6 +2,11 @@ import java.net.http.*;
 import java.net.URI;
 
 public class TurboSignPrepare {
+    // Configuration - Update these values
+    private static final String API_TOKEN = "YOUR_API_TOKEN";
+    private static final String ORG_ID = "YOUR_ORGANIZATION_ID";
+    private static final String BASE_URL = "https://www.turbodocx.com/turbosign";
+    private static final String DOCUMENT_NAME = "Contract Agreement";
     public static void main(String[] args) throws Exception {
         // Step 3: Prepare for Signing
         String documentId = "4a20eca5-7944-430c-97d5-fcce4be24296";
@@ -70,10 +75,10 @@ public class TurboSignPrepare {
         """;
         
         HttpRequest request = HttpRequest.newBuilder()
-            .uri(URI.create("https://www.turbodocx.com/turbosign/documents/" + documentId + "/prepare-for-signing"))
+            .uri(URI.create(BASE_URL + "/documents/" + documentId + "/prepare-for-signing"))
             .header("Content-Type", "application/json")
-            .header("Authorization", "Bearer YOUR_API_TOKEN")
-            .header("x-rapiddocx-org-id", "YOUR_ORGANIZATION_ID")
+            .header("Authorization", "Bearer " + API_TOKEN)
+            .header("x-rapiddocx-org-id", ORG_ID)
             .header("User-Agent", "TurboDocx API Client")
             .POST(HttpRequest.BodyPublishers.ofString(payload))
             .build();

--- a/static/scripts/turbosign/api/step3-prepare/nodejs/express.js
+++ b/static/scripts/turbosign/api/step3-prepare/nodejs/express.js
@@ -4,6 +4,7 @@ const fetch = require('node-fetch');
 const API_TOKEN = "YOUR_API_TOKEN";
 const ORG_ID = "YOUR_ORGANIZATION_ID";
 const BASE_URL = "https://api.turbodocx.com";
+const DOCUMENT_NAME = "Contract Agreement";
 
 // Step 3: Prepare for Signing
 const documentId = "4a20eca5-7944-430c-97d5-fcce4be24296";

--- a/static/scripts/turbosign/api/step3-prepare/nodejs/express.js
+++ b/static/scripts/turbosign/api/step3-prepare/nodejs/express.js
@@ -1,5 +1,10 @@
 const fetch = require('node-fetch');
 
+// Configuration - Update these values
+const API_TOKEN = "YOUR_API_TOKEN";
+const ORG_ID = "YOUR_ORGANIZATION_ID";
+const BASE_URL = "https://www.turbodocx.com/turbosign";
+
 // Step 3: Prepare for Signing
 const documentId = "4a20eca5-7944-430c-97d5-fcce4be24296";
 
@@ -62,12 +67,12 @@ const signatureFields = [
   }
 ];
 
-const response = await fetch(`https://www.turbodocx.com/turbosign/documents/${documentId}/prepare-for-signing`, {
+const response = await fetch(`${BASE_URL}/documents/${documentId}/prepare-for-signing`, {
   method: 'POST',
   headers: {
     'Content-Type': 'application/json',
-    'Authorization': 'Bearer YOUR_API_TOKEN',
-    'x-rapiddocx-org-id': 'YOUR_ORGANIZATION_ID',
+    'Authorization': `Bearer ${API_TOKEN}`,
+    'x-rapiddocx-org-id': ORG_ID,
     'User-Agent': 'TurboDocx API Client'
   },
   body: JSON.stringify(signatureFields)

--- a/static/scripts/turbosign/api/step3-prepare/nodejs/express.js
+++ b/static/scripts/turbosign/api/step3-prepare/nodejs/express.js
@@ -68,20 +68,7 @@ const response = await fetch(`https://www.turbodocx.com/turbosign/documents/${do
     'Content-Type': 'application/json',
     'Authorization': 'Bearer YOUR_API_TOKEN',
     'x-rapiddocx-org-id': 'YOUR_ORGANIZATION_ID',
-    'origin': 'https://www.turbodocx.com',
-    'referer': 'https://www.turbodocx.com',
-    'accept': 'application/json, text/plain, */*',
-    'dnt': '1',
-    'accept-language': 'en-US,en;q=0.9',
-    'priority': 'u=1, i',
-    'sec-ch-ua': '"Not)A;Brand";v="8", "Chromium";v="138", "Google Chrome";v="138"',
-    'sec-ch-ua-mobile': '?0',
-    'sec-ch-ua-platform': '"Windows"',
-    'sec-fetch-dest': 'empty',
-    'sec-fetch-mode': 'cors',
-    'sec-fetch-site': 'same-site',
-    'user-agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/138.0.0.0 Safari/537.36',
-    'x-device-fingerprint': '280624a233f1fd39ce050a9e9d0a4cc9'
+    'User-Agent': 'TurboDocx API Client'
   },
   body: JSON.stringify(signatureFields)
 });

--- a/static/scripts/turbosign/api/step3-prepare/nodejs/express.js
+++ b/static/scripts/turbosign/api/step3-prepare/nodejs/express.js
@@ -3,7 +3,7 @@ const fetch = require('node-fetch');
 // Configuration - Update these values
 const API_TOKEN = "YOUR_API_TOKEN";
 const ORG_ID = "YOUR_ORGANIZATION_ID";
-const BASE_URL = "https://www.turbodocx.com/turbosign";
+const BASE_URL = "https://api.turbodocx.com";
 
 // Step 3: Prepare for Signing
 const documentId = "4a20eca5-7944-430c-97d5-fcce4be24296";

--- a/static/scripts/turbosign/api/step3-prepare/nodejs/fastify.js
+++ b/static/scripts/turbosign/api/step3-prepare/nodejs/fastify.js
@@ -4,6 +4,7 @@ const fetch = require('node-fetch');
 const API_TOKEN = "YOUR_API_TOKEN";
 const ORG_ID = "YOUR_ORGANIZATION_ID";
 const BASE_URL = "https://api.turbodocx.com";
+const DOCUMENT_NAME = "Contract Agreement";
 
 // Step 3: Prepare for Signing
 const documentId = "4a20eca5-7944-430c-97d5-fcce4be24296";

--- a/static/scripts/turbosign/api/step3-prepare/nodejs/fastify.js
+++ b/static/scripts/turbosign/api/step3-prepare/nodejs/fastify.js
@@ -1,5 +1,10 @@
 const fetch = require('node-fetch');
 
+// Configuration - Update these values
+const API_TOKEN = "YOUR_API_TOKEN";
+const ORG_ID = "YOUR_ORGANIZATION_ID";
+const BASE_URL = "https://www.turbodocx.com/turbosign";
+
 // Step 3: Prepare for Signing
 const documentId = "4a20eca5-7944-430c-97d5-fcce4be24296";
 
@@ -62,12 +67,12 @@ const signatureFields = [
   }
 ];
 
-const response = await fetch(`https://www.turbodocx.com/turbosign/documents/${documentId}/prepare-for-signing`, {
+const response = await fetch(`${BASE_URL}/documents/${documentId}/prepare-for-signing`, {
   method: 'POST',
   headers: {
     'Content-Type': 'application/json',
-    'Authorization': 'Bearer YOUR_API_TOKEN',
-    'x-rapiddocx-org-id': 'YOUR_ORGANIZATION_ID',
+    'Authorization': `Bearer ${API_TOKEN}`,
+    'x-rapiddocx-org-id': ORG_ID,
     'User-Agent': 'TurboDocx API Client'
   },
   body: JSON.stringify(signatureFields)

--- a/static/scripts/turbosign/api/step3-prepare/nodejs/fastify.js
+++ b/static/scripts/turbosign/api/step3-prepare/nodejs/fastify.js
@@ -68,20 +68,7 @@ const response = await fetch(`https://www.turbodocx.com/turbosign/documents/${do
     'Content-Type': 'application/json',
     'Authorization': 'Bearer YOUR_API_TOKEN',
     'x-rapiddocx-org-id': 'YOUR_ORGANIZATION_ID',
-    'origin': 'https://www.turbodocx.com',
-    'referer': 'https://www.turbodocx.com',
-    'accept': 'application/json, text/plain, */*',
-    'dnt': '1',
-    'accept-language': 'en-US,en;q=0.9',
-    'priority': 'u=1, i',
-    'sec-ch-ua': '"Not)A;Brand";v="8", "Chromium";v="138", "Google Chrome";v="138"',
-    'sec-ch-ua-mobile': '?0',
-    'sec-ch-ua-platform': '"Windows"',
-    'sec-fetch-dest': 'empty',
-    'sec-fetch-mode': 'cors',
-    'sec-fetch-site': 'same-site',
-    'user-agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/138.0.0.0 Safari/537.36',
-    'x-device-fingerprint': '280624a233f1fd39ce050a9e9d0a4cc9'
+    'User-Agent': 'TurboDocx API Client'
   },
   body: JSON.stringify(signatureFields)
 });

--- a/static/scripts/turbosign/api/step3-prepare/nodejs/fastify.js
+++ b/static/scripts/turbosign/api/step3-prepare/nodejs/fastify.js
@@ -3,7 +3,7 @@ const fetch = require('node-fetch');
 // Configuration - Update these values
 const API_TOKEN = "YOUR_API_TOKEN";
 const ORG_ID = "YOUR_ORGANIZATION_ID";
-const BASE_URL = "https://www.turbodocx.com/turbosign";
+const BASE_URL = "https://api.turbodocx.com";
 
 // Step 3: Prepare for Signing
 const documentId = "4a20eca5-7944-430c-97d5-fcce4be24296";

--- a/static/scripts/turbosign/api/step3-prepare/php.php
+++ b/static/scripts/turbosign/api/step3-prepare/php.php
@@ -3,6 +3,7 @@
 $API_TOKEN = "YOUR_API_TOKEN";
 $ORG_ID = "YOUR_ORGANIZATION_ID";
 $BASE_URL = "https://api.turbodocx.com";
+$DOCUMENT_NAME = "Contract Agreement";
 
 // Step 3: Prepare for Signing
 $document_id = "4a20eca5-7944-430c-97d5-fcce4be24296";

--- a/static/scripts/turbosign/api/step3-prepare/php.php
+++ b/static/scripts/turbosign/api/step3-prepare/php.php
@@ -1,4 +1,10 @@
 <?php
+// Configuration - Update these values
+$API_TOKEN = "YOUR_API_TOKEN";
+$ORG_ID = "YOUR_ORGANIZATION_ID";
+$BASE_URL = "https://www.turbodocx.com/turbosign";
+
+// Step 3: Prepare for Signing
 $document_id = "4a20eca5-7944-430c-97d5-fcce4be24296";
 
 $signature_fields = [
@@ -62,13 +68,13 @@ $signature_fields = [
 
 $ch = curl_init();
 curl_setopt_array($ch, [
-    CURLOPT_URL => "https://www.turbodocx.com/turbosign/documents/$document_id/prepare-for-signing",
+    CURLOPT_URL => $BASE_URL . "/documents/$document_id/prepare-for-signing",
     CURLOPT_POST => true,
     CURLOPT_POSTFIELDS => json_encode($signature_fields),
     CURLOPT_HTTPHEADER => [
         'Content-Type: application/json',
-        'Authorization: Bearer YOUR_API_TOKEN',
-        'x-rapiddocx-org-id: YOUR_ORGANIZATION_ID',
+        'Authorization: Bearer ' . $API_TOKEN,
+        'x-rapiddocx-org-id: ' . $ORG_ID,
         'User-Agent: TurboDocx API Client'
     ],
     CURLOPT_RETURNTRANSFER => true

--- a/static/scripts/turbosign/api/step3-prepare/php.php
+++ b/static/scripts/turbosign/api/step3-prepare/php.php
@@ -2,7 +2,7 @@
 // Configuration - Update these values
 $API_TOKEN = "YOUR_API_TOKEN";
 $ORG_ID = "YOUR_ORGANIZATION_ID";
-$BASE_URL = "https://www.turbodocx.com/turbosign";
+$BASE_URL = "https://api.turbodocx.com";
 
 // Step 3: Prepare for Signing
 $document_id = "4a20eca5-7944-430c-97d5-fcce4be24296";

--- a/static/scripts/turbosign/api/step3-prepare/php.php
+++ b/static/scripts/turbosign/api/step3-prepare/php.php
@@ -69,20 +69,7 @@ curl_setopt_array($ch, [
         'Content-Type: application/json',
         'Authorization: Bearer YOUR_API_TOKEN',
         'x-rapiddocx-org-id: YOUR_ORGANIZATION_ID',
-        'origin: https://www.turbodocx.com',
-        'referer: https://www.turbodocx.com',
-        'accept: application/json, text/plain, */*',
-        'dnt: 1',
-        'accept-language: en-US,en;q=0.9',
-        'priority: u=1, i',
-        'sec-ch-ua: "Not)A;Brand";v="8", "Chromium";v="138", "Google Chrome";v="138"',
-        'sec-ch-ua-mobile: ?0',
-        'sec-ch-ua-platform: "Windows"',
-        'sec-fetch-dest: empty',
-        'sec-fetch-mode: cors',
-        'sec-fetch-site: same-site',
-        'user-agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/138.0.0.0 Safari/537.36',
-        'x-device-fingerprint: 280624a233f1fd39ce050a9e9d0a4cc9'
+        'User-Agent: TurboDocx API Client'
     ],
     CURLOPT_RETURNTRANSFER => true
 ]);

--- a/static/scripts/turbosign/api/step3-prepare/powershell.ps1
+++ b/static/scripts/turbosign/api/step3-prepare/powershell.ps1
@@ -1,7 +1,7 @@
 # Configuration - Update these values
 $API_TOKEN = "YOUR_API_TOKEN"
 $ORG_ID = "YOUR_ORGANIZATION_ID"
-$BASE_URL = "https://www.turbodocx.com/turbosign"
+$BASE_URL = "https://api.turbodocx.com"
 $DOCUMENT_NAME = "Contract Agreement"
 
 # Step 3: Prepare for Signing

--- a/static/scripts/turbosign/api/step3-prepare/powershell.ps1
+++ b/static/scripts/turbosign/api/step3-prepare/powershell.ps1
@@ -1,3 +1,9 @@
+# Configuration - Update these values
+$API_TOKEN = "YOUR_API_TOKEN"
+$ORG_ID = "YOUR_ORGANIZATION_ID"
+$BASE_URL = "https://www.turbodocx.com/turbosign"
+$DOCUMENT_NAME = "Contract Agreement"
+
 # Step 3: Prepare for Signing
 $documentId = "4a20eca5-7944-430c-97d5-fcce4be24296"
 
@@ -62,10 +68,10 @@ $signatureFields = @(
 
 $headers = @{
     'Content-Type' = 'application/json'
-    'Authorization' = 'Bearer YOUR_API_TOKEN'
-    'x-rapiddocx-org-id' = 'YOUR_ORGANIZATION_ID'
+    'Authorization' = "Bearer $API_TOKEN"
+    'x-rapiddocx-org-id' = $ORG_ID
     'User-Agent' = 'TurboDocx API Client'
 }
 
-$response = Invoke-RestMethod -Uri "https://www.turbodocx.com/turbosign/documents/$documentId/prepare-for-signing" -Method Post -Body $signatureFields -Headers $headers -ContentType 'application/json'
+$response = Invoke-RestMethod -Uri "$BASE_URL/documents/$documentId/prepare-for-signing" -Method Post -Body $signatureFields -Headers $headers -ContentType 'application/json'
 $response | ConvertTo-Json

--- a/static/scripts/turbosign/api/step3-prepare/powershell.ps1
+++ b/static/scripts/turbosign/api/step3-prepare/powershell.ps1
@@ -64,9 +64,7 @@ $headers = @{
     'Content-Type' = 'application/json'
     'Authorization' = 'Bearer YOUR_API_TOKEN'
     'x-rapiddocx-org-id' = 'YOUR_ORGANIZATION_ID'
-    'origin' = 'https://www.turbodocx.com'
-    'referer' = 'https://www.turbodocx.com'
-    'accept' = 'application/json, text/plain, */*'
+    'User-Agent' = 'TurboDocx API Client'
 }
 
 $response = Invoke-RestMethod -Uri "https://www.turbodocx.com/turbosign/documents/$documentId/prepare-for-signing" -Method Post -Body $signatureFields -Headers $headers -ContentType 'application/json'

--- a/static/scripts/turbosign/api/step3-prepare/python/fastapi.py
+++ b/static/scripts/turbosign/api/step3-prepare/python/fastapi.py
@@ -4,7 +4,7 @@ import json
 # Configuration - Update these values
 API_TOKEN = "YOUR_API_TOKEN"
 ORG_ID = "YOUR_ORGANIZATION_ID"
-BASE_URL = "https://www.turbodocx.com/turbosign"
+BASE_URL = "https://api.turbodocx.com"
 
 # Step 3: Prepare for Signing
 document_id = "4a20eca5-7944-430c-97d5-fcce4be24296"

--- a/static/scripts/turbosign/api/step3-prepare/python/fastapi.py
+++ b/static/scripts/turbosign/api/step3-prepare/python/fastapi.py
@@ -1,15 +1,20 @@
 import requests
 import json
 
+# Configuration - Update these values
+API_TOKEN = "YOUR_API_TOKEN"
+ORG_ID = "YOUR_ORGANIZATION_ID"
+BASE_URL = "https://www.turbodocx.com/turbosign"
+
 # Step 3: Prepare for Signing
 document_id = "4a20eca5-7944-430c-97d5-fcce4be24296"
 
-url = f"https://www.turbodocx.com/turbosign/documents/{document_id}/prepare-for-signing"
+url = f"{BASE_URL}/documents/{document_id}/prepare-for-signing"
 
 headers = {
     "Content-Type": "application/json",
-    "Authorization": "Bearer YOUR_API_TOKEN",
-    "x-rapiddocx-org-id": "YOUR_ORGANIZATION_ID",
+    "Authorization": f"Bearer {API_TOKEN}",
+    "x-rapiddocx-org-id": ORG_ID,
     "User-Agent": "TurboDocx API Client"
 }
 

--- a/static/scripts/turbosign/api/step3-prepare/python/fastapi.py
+++ b/static/scripts/turbosign/api/step3-prepare/python/fastapi.py
@@ -5,6 +5,7 @@ import json
 API_TOKEN = "YOUR_API_TOKEN"
 ORG_ID = "YOUR_ORGANIZATION_ID"
 BASE_URL = "https://api.turbodocx.com"
+DOCUMENT_NAME = "Contract Agreement"
 
 # Step 3: Prepare for Signing
 document_id = "4a20eca5-7944-430c-97d5-fcce4be24296"

--- a/static/scripts/turbosign/api/step3-prepare/python/fastapi.py
+++ b/static/scripts/turbosign/api/step3-prepare/python/fastapi.py
@@ -10,20 +10,7 @@ headers = {
     "Content-Type": "application/json",
     "Authorization": "Bearer YOUR_API_TOKEN",
     "x-rapiddocx-org-id": "YOUR_ORGANIZATION_ID",
-    "origin": "https://www.turbodocx.com",
-    "referer": "https://www.turbodocx.com",
-    "accept": "application/json, text/plain, */*",
-    "dnt": "1",
-    "accept-language": "en-US,en;q=0.9",
-    "priority": "u=1, i",
-    "sec-ch-ua": "\"Not)A;Brand\";v=\"8\", \"Chromium\";v=\"138\", \"Google Chrome\";v=\"138\"",
-    "sec-ch-ua-mobile": "?0",
-    "sec-ch-ua-platform": "\"Windows\"",
-    "sec-fetch-dest": "empty",
-    "sec-fetch-mode": "cors",
-    "sec-fetch-site": "same-site",
-    "user-agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/138.0.0.0 Safari/537.36",
-    "x-device-fingerprint": "280624a233f1fd39ce050a9e9d0a4cc9"
+    "User-Agent": "TurboDocx API Client"
 }
 
 signature_fields = [

--- a/static/scripts/turbosign/api/step3-prepare/python/flask.py
+++ b/static/scripts/turbosign/api/step3-prepare/python/flask.py
@@ -4,7 +4,7 @@ import json
 # Configuration - Update these values
 API_TOKEN = "YOUR_API_TOKEN"
 ORG_ID = "YOUR_ORGANIZATION_ID"
-BASE_URL = "https://www.turbodocx.com/turbosign"
+BASE_URL = "https://api.turbodocx.com"
 
 # Step 3: Prepare for Signing
 document_id = "4a20eca5-7944-430c-97d5-fcce4be24296"

--- a/static/scripts/turbosign/api/step3-prepare/python/flask.py
+++ b/static/scripts/turbosign/api/step3-prepare/python/flask.py
@@ -1,15 +1,20 @@
 import requests
 import json
 
+# Configuration - Update these values
+API_TOKEN = "YOUR_API_TOKEN"
+ORG_ID = "YOUR_ORGANIZATION_ID"
+BASE_URL = "https://www.turbodocx.com/turbosign"
+
 # Step 3: Prepare for Signing
 document_id = "4a20eca5-7944-430c-97d5-fcce4be24296"
 
-url = f"https://www.turbodocx.com/turbosign/documents/{document_id}/prepare-for-signing"
+url = f"{BASE_URL}/documents/{document_id}/prepare-for-signing"
 
 headers = {
     "Content-Type": "application/json",
-    "Authorization": "Bearer YOUR_API_TOKEN",
-    "x-rapiddocx-org-id": "YOUR_ORGANIZATION_ID",
+    "Authorization": f"Bearer {API_TOKEN}",
+    "x-rapiddocx-org-id": ORG_ID,
     "User-Agent": "TurboDocx API Client"
 }
 

--- a/static/scripts/turbosign/api/step3-prepare/python/flask.py
+++ b/static/scripts/turbosign/api/step3-prepare/python/flask.py
@@ -5,6 +5,7 @@ import json
 API_TOKEN = "YOUR_API_TOKEN"
 ORG_ID = "YOUR_ORGANIZATION_ID"
 BASE_URL = "https://api.turbodocx.com"
+DOCUMENT_NAME = "Contract Agreement"
 
 # Step 3: Prepare for Signing
 document_id = "4a20eca5-7944-430c-97d5-fcce4be24296"

--- a/static/scripts/turbosign/api/step3-prepare/python/flask.py
+++ b/static/scripts/turbosign/api/step3-prepare/python/flask.py
@@ -10,20 +10,7 @@ headers = {
     "Content-Type": "application/json",
     "Authorization": "Bearer YOUR_API_TOKEN",
     "x-rapiddocx-org-id": "YOUR_ORGANIZATION_ID",
-    "origin": "https://www.turbodocx.com",
-    "referer": "https://www.turbodocx.com",
-    "accept": "application/json, text/plain, */*",
-    "dnt": "1",
-    "accept-language": "en-US,en;q=0.9",
-    "priority": "u=1, i",
-    "sec-ch-ua": "\"Not)A;Brand\";v=\"8\", \"Chromium\";v=\"138\", \"Google Chrome\";v=\"138\"",
-    "sec-ch-ua-mobile": "?0",
-    "sec-ch-ua-platform": "\"Windows\"",
-    "sec-fetch-dest": "empty",
-    "sec-fetch-mode": "cors",
-    "sec-fetch-site": "same-site",
-    "user-agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/138.0.0.0 Safari/537.36",
-    "x-device-fingerprint": "280624a233f1fd39ce050a9e9d0a4cc9"
+    "User-Agent": "TurboDocx API Client"
 }
 
 signature_fields = [

--- a/static/scripts/turbosign/api/step3-prepare/ruby.rb
+++ b/static/scripts/turbosign/api/step3-prepare/ruby.rb
@@ -5,7 +5,7 @@ require 'json'
 # Configuration - Update these values
 API_TOKEN = "YOUR_API_TOKEN"
 ORG_ID = "YOUR_ORGANIZATION_ID"
-BASE_URL = "https://www.turbodocx.com/turbosign"
+BASE_URL = "https://api.turbodocx.com"
 DOCUMENT_NAME = "Contract Agreement"
 
 # Step 3: Prepare for Signing

--- a/static/scripts/turbosign/api/step3-prepare/ruby.rb
+++ b/static/scripts/turbosign/api/step3-prepare/ruby.rb
@@ -73,9 +73,7 @@ request = Net::HTTP::Post.new(uri)
 request['Content-Type'] = 'application/json'
 request['Authorization'] = 'Bearer YOUR_API_TOKEN'
 request['x-rapiddocx-org-id'] = 'YOUR_ORGANIZATION_ID'
-request['origin'] = 'https://www.turbodocx.com'
-request['referer'] = 'https://www.turbodocx.com'
-request['accept'] = 'application/json, text/plain, */*'
+request['User-Agent'] = 'TurboDocx API Client'
 request.body = signature_fields.to_json
 
 response = http.request(request)

--- a/static/scripts/turbosign/api/step3-prepare/ruby.rb
+++ b/static/scripts/turbosign/api/step3-prepare/ruby.rb
@@ -2,6 +2,12 @@ require 'net/http'
 require 'uri'
 require 'json'
 
+# Configuration - Update these values
+API_TOKEN = "YOUR_API_TOKEN"
+ORG_ID = "YOUR_ORGANIZATION_ID"
+BASE_URL = "https://www.turbodocx.com/turbosign"
+DOCUMENT_NAME = "Contract Agreement"
+
 # Step 3: Prepare for Signing
 document_id = "4a20eca5-7944-430c-97d5-fcce4be24296"
 
@@ -64,15 +70,15 @@ signature_fields = [
   }
 ]
 
-uri = URI("https://www.turbodocx.com/turbosign/documents/#{document_id}/prepare-for-signing")
+uri = URI("#{BASE_URL}/documents/#{document_id}/prepare-for-signing")
 
 http = Net::HTTP.new(uri.host, uri.port)
 http.use_ssl = true
 
 request = Net::HTTP::Post.new(uri)
 request['Content-Type'] = 'application/json'
-request['Authorization'] = 'Bearer YOUR_API_TOKEN'
-request['x-rapiddocx-org-id'] = 'YOUR_ORGANIZATION_ID'
+request['Authorization'] = "Bearer #{API_TOKEN}"
+request['x-rapiddocx-org-id'] = ORG_ID
 request['User-Agent'] = 'TurboDocx API Client'
 request.body = signature_fields.to_json
 


### PR DESCRIPTION
## Summary
- Added configuration constants to all 44 TurboSign API example files
- Eliminated hardcoded values for better developer experience  
- Fixed base URL to use correct `https://api.turbodocx.com`
- Ensured consistent structure across all programming languages

## Changes
- **Python (8 files)**: FastAPI & Flask examples across all workflow steps
- **NodeJS (8 files)**: Express & Fastify examples across all workflow steps  
- **PHP (4 files)**: cURL examples across all workflow steps
- **Go (4 files)**: net/http examples across all workflow steps
- **C# (8 files)**: Controller & Minimal API examples across all workflow steps
- **Java (4 files)**: HttpClient examples across all workflow steps
- **Ruby (4 files)**: Net::HTTP examples across all workflow steps
- **PowerShell (4 files)**: Invoke-RestMethod examples across all workflow steps

## Benefits
✅ Developers only need to update constants at the top of each file  
✅ No more hunting for scattered hardcoded values throughout code  
✅ Consistent structure across all 8 programming languages  
✅ Correct API endpoint for all examples

🤖 Generated with [Claude Code](https://claude.ai/code)