### PR TITLE
docs: add Wrike API key link at Step 2

### DIFF
--- a/docs/Integrations/Wrike/setting-up-automation.md
+++ b/docs/Integrations/Wrike/setting-up-automation.md
@@ -46,6 +46,10 @@ Navigate to the **Integrations** page within TurboDocx. Locate the **Wrike Integ
 
 ### Step 2: Enter Your Wrike API Key
 
+:::tip Need an API key?
+See [Wrike's API documentation](https://help.wrike.com/hc/en-us/articles/210409445-Wrike-API) for how to generate a permanent access token.
+:::
+
 In the Wrike Automations connection dialog, locate the **Enter your Wrike API key** text input field. Click inside the field and paste your Wrike API access token.
 
 ![Enter Wrike API Key](/img/wrike-integration/Step02-FocusApiKeyInput.png)


### PR DESCRIPTION
## Summary
- Adds a tip callout at Step 2 (Enter Your Wrike API Key) linking to Wrike's API docs for generating a permanent access token
- Makes the link discoverable for users navigating directly via anchor link

## Test plan
- [ ] Verify tip renders at `/docs/Integrations/Wrike/setting-up-automation#step-2-enter-your-wrike-api-key`

🤖 Generated with [Claude Code](https://claude.com/claude-code)