### PR TITLE
docs: add "Install with AI Agents" page for TurboDocx Quickstart Skill

### DIFF
--- a/docs/SDKs/agent-skills.md
+++ b/docs/SDKs/agent-skills.md
@@ -1,0 +1,162 @@
+---
+title: Install with AI Agents (Agent Skills)
+sidebar_position: 0
+sidebar_label: Install with AI Agents
+description: Install the TurboDocx SDK and @turbodocx/html-to-docx into any project in one prompt using the TurboDocx Agent Skill — works with Claude Code, GitHub Copilot, Cursor, OpenCode, OpenAI Codex CLI, and Gemini CLI.
+keywords:
+  - agent skills
+  - ai agent
+  - claude code
+  - github copilot
+  - cursor
+  - opencode
+  - openai codex
+  - gemini cli
+  - npx skills
+  - turbodocx skill
+  - turbosign skill
+  - turbopartner skill
+  - html-to-docx skill
+  - automated sdk install
+---
+
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+# Install TurboDocx with AI Agents
+
+The TurboDocx Quickstart Skill is an [Agent Skills](https://agentskills.io) plugin that lets your AI coding agent install and wire up the TurboDocx SDK or `@turbodocx/html-to-docx` in a single prompt. It detects your project's language and framework, installs the package, configures environment variables, and generates working integration code that matches your existing codebase patterns.
+
+[![skills.sh](https://skills.sh/b/TurboDocx/quickstart)](https://skills.sh/TurboDocx/quickstart)
+
+Works with:
+
+- **Claude Code**
+- **GitHub Copilot** (VS Code)
+- **Cursor**
+- **OpenCode**
+- **OpenAI Codex CLI**
+- **Gemini CLI**
+- Any tool that supports the [Agent Skills](https://agentskills.io) standard
+
+## Skills
+
+| Skill | What it does |
+| :--- | :--- |
+| **`turbodocx-sdk`** | Installs the TurboDocx SDK and generates working **TurboSign** (digital signatures) and **TurboPartner** (partner/org management) integration code. Supports JavaScript/TypeScript, Python, Go, PHP, and Java. |
+| **`turbodocx-html-to-docx`** | Sets up [`@turbodocx/html-to-docx`](https://www.npmjs.com/package/@turbodocx/html-to-docx) to convert HTML to Microsoft Word documents in Node.js, browser, or hybrid projects. |
+
+## Install
+
+The fastest path is the `npx skills` CLI, which auto-detects which agents you have installed and drops the skills into the right config directory.
+
+<Tabs groupId="skill-install">
+  <TabItem value="both" label="Both skills" default>
+
+```bash
+npx skills add TurboDocx/quickstart
+```
+
+  </TabItem>
+  <TabItem value="sdk" label="SDK only">
+
+```bash
+npx skills add TurboDocx/quickstart --skill turbodocx-sdk
+```
+
+  </TabItem>
+  <TabItem value="html" label="html-to-docx only">
+
+```bash
+npx skills add TurboDocx/quickstart --skill turbodocx-html-to-docx
+```
+
+  </TabItem>
+  <TabItem value="global" label="Globally (all projects)">
+
+```bash
+npx skills add TurboDocx/quickstart -g
+```
+
+  </TabItem>
+</Tabs>
+
+:::tip Claude Code plugin
+If you use Claude Code, you can also install via the plugin command:
+
+```bash
+claude plugin add turbodocx/quickstart
+```
+
+:::
+
+## Usage
+
+After installing, invoke the skill in your editor or terminal:
+
+```text
+/turbodocx-sdk
+```
+
+The skill will:
+
+1. **Detect** your project language from manifest files (`package.json`, `pyproject.toml`, `go.mod`, `composer.json`, `pom.xml`).
+2. **Ask** which product you need — TurboSign, TurboPartner, or both.
+3. **Install** the SDK with your project's package manager.
+4. **Configure** environment variables in `.env` and `.env.example`.
+5. **Analyze** your codebase structure (Express, FastAPI, Spring Boot, Laravel, Gin, etc.).
+6. **Generate** integration code that matches your existing patterns, with route handlers wired into your app.
+
+### Shortcuts
+
+Skip the product selection prompt:
+
+```text
+/turbodocx-sdk turbosign       # TurboSign only
+/turbodocx-sdk turbopartner    # TurboPartner only
+/turbodocx-sdk both            # Both products
+```
+
+For HTML-to-DOCX:
+
+```text
+/turbodocx-html-to-docx
+```
+
+## What gets generated
+
+### TurboSign
+
+- Client configuration with environment variable loading
+- `sendSignature()` — send documents for e-signature
+- `getStatus()` — check document/recipient status
+- A route handler wired into your existing app
+
+### TurboPartner
+
+- Partner client configuration
+- `createOrganization()` — provision customer organizations
+- `listOrganizations()` — list managed orgs
+- A route handler wired into your existing app
+
+### `@turbodocx/html-to-docx`
+
+- Helper module appropriate for your framework (Express, Next.js API route, Fastify, NestJS controller, etc.)
+- A working endpoint that returns a `.docx` response
+- Browser-bundle setup if you're running in a static HTML / no-bundler project
+
+## Prerequisites
+
+- Get your API credentials from the [TurboDocx dashboard](https://app.turbodocx.com).
+- Node.js 18+ if using `npx`.
+
+## Source and feedback
+
+The skill is open source at **[github.com/TurboDocx/quickstart](https://github.com/TurboDocx/quickstart)** — issues, PRs, and feature requests welcome.
+
+## Related
+
+- [SDKs Overview](./index.md)
+- [TurboSign JavaScript SDK](./javascript.md)
+- [TurboSign Python SDK](./python.md)
+- [TurboPartner JavaScript SDK](./partner-javascript.md)

--- a/docs/SDKs/agent-skills.md
+++ b/docs/SDKs/agent-skills.md
@@ -43,7 +43,7 @@ Works with:
 
 | Skill | What it does |
 | :--- | :--- |
-| **`turbodocx-sdk`** | Installs the TurboDocx SDK and generates working **TurboSign** (digital signatures) and **TurboPartner** (partner/org management) integration code. Supports JavaScript/TypeScript, Python, Go, PHP, and Java. |
+| **`turbodocx-sdk`** | Installs the TurboDocx SDK and generates working integration code for **TurboSign** (e-signatures), **Deliverable** (template document generation), **TurboQuote** (quotes & CPQ), **TurboWebhooks** (signature events), and **TurboPartner** (partner/org management). Supports JavaScript/TypeScript, Python, Go, PHP, and Java. |
 | **`turbodocx-html-to-docx`** | Sets up [`@turbodocx/html-to-docx`](https://www.npmjs.com/package/@turbodocx/html-to-docx) to convert HTML to Microsoft Word documents in Node.js, browser, or hybrid projects. |
 
 ## Install
@@ -101,7 +101,7 @@ After installing, invoke the skill in your editor or terminal:
 The skill will:
 
 1. **Detect** your project language from manifest files (`package.json`, `pyproject.toml`, `go.mod`, `composer.json`, `pom.xml`).
-2. **Ask** which product you need — TurboSign, TurboPartner, or both.
+2. **Ask** which product you need. By default it offers **TurboSign** and **Deliverable** (and the generate-then-sign combo); **TurboPartner**, **TurboWebhooks**, and **TurboQuote** are opt-in via their shortcuts (below).
 3. **Install** the SDK with your project's package manager.
 4. **Configure** environment variables in `.env` and `.env.example`.
 5. **Analyze** your codebase structure (Express, FastAPI, Spring Boot, Laravel, Gin, etc.).
@@ -112,9 +112,13 @@ The skill will:
 Skip the product selection prompt:
 
 ```text
-/turbodocx-sdk turbosign       # TurboSign only
-/turbodocx-sdk turbopartner    # TurboPartner only
-/turbodocx-sdk both            # Both products
+/turbodocx-sdk turbosign              # TurboSign (e-signatures) only
+/turbodocx-sdk deliverable            # Deliverable (template document generation) only
+/turbodocx-sdk turbosign+deliverable  # generate-then-sign workflow
+/turbodocx-sdk turboquote             # TurboQuote (quotes, catalog, price books) only
+/turbodocx-sdk turbowebhooks          # TurboWebhooks (signature events) only
+/turbodocx-sdk turbopartner           # TurboPartner (org provisioning) only
+/turbodocx-sdk both                   # TurboSign + Deliverable
 ```
 
 For HTML-to-DOCX:
@@ -131,6 +135,23 @@ For HTML-to-DOCX:
 - `sendSignature()` — send documents for e-signature
 - `getStatus()` — check document/recipient status
 - A route handler wired into your existing app
+
+### Deliverable
+
+- `generateDeliverable()` — render a document from a template with variable substitution
+- `getDeliverableDetails()` — fetch a generated deliverable by ID
+- If you also pick TurboSign, the generate-then-sign workflow (render a template, then route it for signature)
+
+### TurboQuote
+
+- `createQuote()` and line-item helpers for quotes and proposals
+- Optional catalog scaffolding — `createProduct()`, `createBundle()`, `createPriceBook()`, `applyPriceBook()`
+- Optional payments path — `createPaymentLink()` and `getPaymentStatus()` for collecting payment on a quote
+
+### TurboWebhooks
+
+- A verified webhook endpoint that subscribes to signature events (for example `signature.document.completed`)
+- `X-TurboDocx-Signature` verification so you can trust incoming payloads
 
 ### TurboPartner
 

--- a/docs/SDKs/agent-skills.md
+++ b/docs/SDKs/agent-skills.md
@@ -27,7 +27,7 @@ import TabItem from '@theme/TabItem';
 
 The TurboDocx Quickstart Skill is an [Agent Skills](https://agentskills.io) plugin that lets your AI coding agent install and wire up the TurboDocx SDK or `@turbodocx/html-to-docx` in a single prompt. It detects your project's language and framework, installs the package, configures environment variables, and generates working integration code that matches your existing codebase patterns.
 
-[![skills.sh](https://skills.sh/b/TurboDocx/quickstart)](https://skills.sh/TurboDocx/quickstart)
+<a href="https://skills.sh/TurboDocx/quickstart" target="_blank" rel="noopener noreferrer"><img src="https://skills.sh/b/TurboDocx/quickstart" alt="TurboDocx quickstart on skills.sh" height="28" /></a>
 
 Works with:
 
@@ -80,15 +80,6 @@ npx skills add TurboDocx/quickstart -g
 
   </TabItem>
 </Tabs>
-
-:::tip Claude Code plugin
-If you use Claude Code, you can also install via the plugin command:
-
-```bash
-claude plugin add turbodocx/quickstart
-```
-
-:::
 
 ## Usage
 

--- a/docs/SDKs/agent-skills.md
+++ b/docs/SDKs/agent-skills.md
@@ -125,30 +125,35 @@ For HTML-to-DOCX:
 - Client configuration with environment variable loading
 - `sendSignature()` — send documents for e-signature
 - `getStatus()` — check document/recipient status
+- `download()` — retrieve the signed PDF
+- Optional helpers when you need them: `createSignatureReviewLink()` (preview before sending), `void()`, `resend()`, and `getAuditTrail()`
 - A route handler wired into your existing app
 
 ### Deliverable
 
 - `generateDeliverable()` — render a document from a template with variable substitution
 - `getDeliverableDetails()` — fetch a generated deliverable by ID
+- `downloadPDF()` / `downloadSourceFile()` — download the rendered output
 - If you also pick TurboSign, the generate-then-sign workflow (render a template, then route it for signature)
 
 ### TurboQuote
 
-- `createQuote()` and line-item helpers for quotes and proposals
+- `createQuote()`, `addLineItems()`, `sendQuote()`, `downloadQuotePdf()` — build, send, and export quotes and proposals
 - Optional catalog scaffolding — `createProduct()`, `createBundle()`, `createPriceBook()`, `applyPriceBook()`
-- Optional payments path — `createPaymentLink()` and `getPaymentStatus()` for collecting payment on a quote
+- Optional payments path — `getPaymentConnectionStatus()` (gate on the seller being connected), `createPaymentLink()`, and `getPaymentStatus()`, plus a verified `quote.payment.succeeded` webhook (adds `TURBODOCX_WEBHOOK_SECRET`)
 
 ### TurboWebhooks
 
 - A verified webhook endpoint that subscribes to signature events (for example `signature.document.completed`)
 - `X-TurboDocx-Signature` verification so you can trust incoming payloads
+- Requires an **administrator-role** API key (non-admin keys are rejected); the endpoint is registered under the fixed name `signature`
 
 ### TurboPartner
 
 - Partner client configuration
 - `createOrganization()` — provision customer organizations
 - `listOrganizations()` — list managed orgs
+- `updateOrganizationEntitlements()` — set an organization's features and entitlements
 - A route handler wired into your existing app
 
 ### `@turbodocx/html-to-docx`
@@ -159,8 +164,13 @@ For HTML-to-DOCX:
 
 ## Prerequisites
 
-- Get your API credentials from the [TurboDocx dashboard](https://app.turbodocx.com).
-- Node.js 18+ if using `npx`.
+- **API credentials** from the [TurboDocx dashboard](https://app.turbodocx.com). Which ones depend on the product (the skill writes them into `.env` and `.env.example` for you):
+  - Most products use `TURBODOCX_API_KEY` + `TURBODOCX_ORG_ID`.
+  - **TurboSign** also needs a verified `TURBODOCX_SENDER_EMAIL` (plus optional `TURBODOCX_SENDER_NAME`) — `sendSignature()` fails without it.
+  - **TurboWebhooks** needs an **administrator-role** API key.
+  - **TurboPartner** uses separate `TURBODOCX_PARTNER_API_KEY` + `TURBODOCX_PARTNER_ID`.
+  - **TurboQuote payments** add `TURBODOCX_WEBHOOK_SECRET`.
+- Node.js to run the `npx skills` installer.
 
 ## Source and feedback
 

--- a/docs/SDKs/index.md
+++ b/docs/SDKs/index.md
@@ -36,6 +36,14 @@ All five modules ship in the **same package** for each language — pick the one
 
 TurboSign, Deliverable, TurboQuote, and TurboWebhooks all use the same `TURBODOCX_API_KEY` + `TURBODOCX_ORG_ID`. See [credential requirements](#which-credentials-does-each-product-need) below.
 
+:::tip Install with one prompt
+Skip the boilerplate — use the [TurboDocx Agent Skill](./agent-skills.md) to install the SDK, configure environment variables, and generate working integration code via Claude Code, GitHub Copilot, Cursor, OpenCode, Codex CLI, or Gemini CLI:
+
+```bash
+npx skills add TurboDocx/quickstart
+```
+:::
+
 ## TurboSign SDKs
 
 Send documents for legally-binding eSignatures with full audit trails.

--- a/sidebars.js
+++ b/sidebars.js
@@ -138,6 +138,11 @@ const sidebars = {
       },
       items: [
         {
+          type: 'doc',
+          id: 'SDKs/agent-skills',
+          label: 'Install with AI Agents',
+        },
+        {
           type: 'category',
           label: 'TurboSign SDKs',
           collapsed: false,

--- a/src/components/QuickstartSkillNudge.jsx
+++ b/src/components/QuickstartSkillNudge.jsx
@@ -99,6 +99,9 @@ export default function QuickstartSkillNudge({
             <GitHubIcon />
             <span>View on GitHub</span>
           </a>
+          <a href="/docs/SDKs/agent-skills" className={styles.github}>
+            <span>Full install guide →</span>
+          </a>
         </div>
       </div>
 


### PR DESCRIPTION
## Summary
- New page **SDKs → Install with AI Agents** documenting `npx skills add TurboDocx/quickstart` for both the `turbodocx-sdk` and `turbodocx-html-to-docx` skills.
- Sidebar entry placed above the TurboSign/TurboPartner/Deliverable sub-categories so it's the first thing developers see after the overview.
- Tip callout added to the existing SDKs overview so users landing there discover the AI-agent install path.

Skill source: [github.com/TurboDocx/quickstart](https://github.com/TurboDocx/quickstart)
Badge: [skills.sh/TurboDocx/quickstart](https://skills.sh/TurboDocx/quickstart)

## Why this page
Multiple AI-coding-agent registries (skills.sh, add-skill.org, awesome-claude-code lists) link back to canonical product docs. Having a dedicated page here gives those registries a target, helps Orama search surface the install path, and lets us link from the SDK READMEs and the dotcom marketing pages to a single source of truth.

## Test plan
- [ ] `npm start` locally and confirm the new sidebar entry renders under SDKs
- [ ] Open the page and confirm the tabbed install snippets render
- [ ] Click each related-page link at the bottom to confirm anchors resolve
- [ ] Confirm the tip callout on the SDKs overview links to the new page
- [ ] Search "agent skill" / "claude code" in the live preview and confirm Orama returns the new page

## Follow-ups (separate PRs)
- DotCom blog + newsroom + product page + home-page developer tab (in flight)
- html-to-docx README update already merged via [TurboDocx/html-to-docx#195](https://github.com/TurboDocx/html-to-docx/pull/195) (still in draft awaiting review)

🤖 Generated with [Claude Code](https://claude.com/claude-code)