### PR TITLE
Redesign QuickstartSkillNudge as a terminal-style card

### DIFF
--- a/src/components/QuickstartSkillNudge.jsx
+++ b/src/components/QuickstartSkillNudge.jsx
@@ -1,28 +1,58 @@
 import React, { useState } from 'react';
+import styles from './QuickstartSkillNudge.module.css';
 
 /**
  * Top-of-page nudge encouraging readers to use the TurboDocx Quickstart agent
  * skill to scaffold the integration instead of hand-writing boilerplate.
  *
- * Renders a card with:
+ * Renders a developer-styled terminal card with:
  *   - Headline + sub-copy
- *   - Live skill count badge (skills.sh)
- *   - A copy-pasteable `npx skills add ...` command (with a copy button)
+ *   - Live skill count badge (skills.sh) + a link to the GitHub repo
+ *   - A copy-pasteable `npx skills add ...` install command (with a copy button)
  *   - The exact slash-command to run inside the agent
- *   - Link to the GitHub repo
  *
  * Props:
  *   command  — slash command displayed inside the agent (e.g. "/turbodocx-sdk turbowebhooks")
  *   product  — short product name used in the body copy ("TurboWebhooks", "TurboSign", …)
  */
+
+const INSTALL_CMD = 'npx skills add TurboDocx/quickstart';
+const REPO_URL = 'https://github.com/TurboDocx/quickstart';
+const BADGE_URL = 'https://skills.sh/b/TurboDocx/quickstart';
+
+function BoltIcon() {
+  return (
+    <svg className={styles.bolt} viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+      <path d="M13 2 4 14h6l-1 8 9-12h-6l1-8z" />
+    </svg>
+  );
+}
+
+function GitHubIcon() {
+  return (
+    <svg className={styles.ghIcon} viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+      <path d="M12 .5C5.73.5.5 5.73.5 12c0 5.08 3.29 9.39 7.86 10.91.58.11.79-.25.79-.55 0-.27-.01-1.18-.02-2.14-3.2.7-3.88-1.36-3.88-1.36-.52-1.32-1.27-1.67-1.27-1.67-1.04-.71.08-.7.08-.7 1.15.08 1.76 1.18 1.76 1.18 1.02 1.74 2.68 1.24 3.34.95.1-.74.4-1.24.72-1.53-2.55-.29-5.24-1.28-5.24-5.69 0-1.26.45-2.29 1.18-3.1-.12-.29-.51-1.46.11-3.04 0 0 .96-.31 3.15 1.18a10.97 10.97 0 0 1 5.74 0c2.19-1.49 3.15-1.18 3.15-1.18.62 1.58.23 2.75.11 3.04.73.81 1.18 1.84 1.18 3.1 0 4.42-2.69 5.4-5.25 5.69.41.36.78 1.07.78 2.16 0 1.56-.01 2.81-.01 3.19 0 .31.21.67.8.55C20.21 21.39 23.5 17.08 23.5 12 23.5 5.73 18.27.5 12 .5z" />
+    </svg>
+  );
+}
+
+function CopyIcon({ copied }) {
+  return copied ? (
+    <svg className={styles.copyIcon} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.4" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+      <path d="M20 6 9 17l-5-5" />
+    </svg>
+  ) : (
+    <svg className={styles.copyIcon} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+      <rect x="9" y="9" width="11" height="11" rx="2" />
+      <path d="M5 15V5a2 2 0 0 1 2-2h10" />
+    </svg>
+  );
+}
+
 export default function QuickstartSkillNudge({
   command = '/turbodocx-sdk',
   product = 'TurboDocx',
 }) {
-  const INSTALL_CMD = 'npx skills add TurboDocx/quickstart';
-  const REPO_URL = 'https://github.com/TurboDocx/quickstart';
-  const BADGE_URL = 'https://skills.sh/b/TurboDocx/quickstart';
-
   const [copied, setCopied] = useState(false);
 
   const copyInstall = async () => {
@@ -36,239 +66,73 @@ export default function QuickstartSkillNudge({
       ta.value = INSTALL_CMD;
       document.body.appendChild(ta);
       ta.select();
-      try { document.execCommand('copy'); setCopied(true); setTimeout(() => setCopied(false), 1800); } catch {}
+      try {
+        document.execCommand('copy');
+        setCopied(true);
+        setTimeout(() => setCopied(false), 1800);
+      } catch {}
       document.body.removeChild(ta);
     }
   };
 
-  // ── styles ────────────────────────────────────────────────────────────
-  const card = {
-    position: 'relative',
-    margin: '0 0 2rem 0',
-    padding: '1.25rem 1.5rem 1.1rem',
-    borderRadius: '12px',
-    border: '1px solid var(--ifm-color-emphasis-300)',
-    background:
-      'linear-gradient(135deg, rgba(20,163,139,0.10) 0%, rgba(20,163,139,0.02) 55%, rgba(20,163,139,0) 100%)',
-    boxShadow: '0 1px 2px rgba(0,0,0,0.04)',
-    overflow: 'hidden',
-  };
-
-  const accentBar = {
-    position: 'absolute',
-    top: 0,
-    left: 0,
-    bottom: 0,
-    width: '4px',
-    background: 'linear-gradient(180deg, #14A38B 0%, #0EBE7F 100%)',
-  };
-
-  const header = {
-    display: 'flex',
-    alignItems: 'center',
-    justifyContent: 'space-between',
-    gap: '0.75rem',
-    marginBottom: '0.5rem',
-    flexWrap: 'wrap',
-  };
-
-  const titleWrap = {
-    display: 'flex',
-    alignItems: 'center',
-    gap: '0.6rem',
-  };
-
-  const iconBox = {
-    width: '28px',
-    height: '28px',
-    flex: '0 0 auto',
-    display: 'flex',
-    alignItems: 'center',
-    justifyContent: 'center',
-    borderRadius: '6px',
-    background: 'linear-gradient(135deg, #14A38B 0%, #0EBE7F 100%)',
-    color: '#fff',
-    boxShadow: '0 1px 4px rgba(20, 163, 139, 0.45)',
-  };
-
-  const titleText = {
-    margin: 0,
-    fontSize: '1.05rem',
-    fontWeight: 700,
-    color: 'var(--ifm-heading-color, inherit)',
-    letterSpacing: '-0.01em',
-  };
-
-  const badgeImg = {
-    height: '20px',
-    verticalAlign: 'middle',
-  };
-
-  const subcopy = {
-    margin: '0 0 0.9rem 0',
-    fontSize: '0.93rem',
-    lineHeight: 1.5,
-    color: 'var(--ifm-color-emphasis-700)',
-  };
-
-  // Terminal-styled box: dark in both light and dark mode (classic terminal look)
-  const codeBlock = {
-    position: 'relative',
-    display: 'flex',
-    alignItems: 'stretch',
-    background: '#1b1b1d',
-    border: '1px solid #2d2d30',
-    borderRadius: '8px',
-    fontFamily: 'var(--ifm-font-family-monospace, ui-monospace, SFMono-Regular, monospace)',
-    fontSize: '0.88rem',
-    lineHeight: 1.4,
-    margin: '0 0 0.85rem 0',
-  };
-
-  const codeText = {
-    flex: '1 1 auto',
-    padding: '0.7rem 0.9rem',
-    color: '#f0f0f0',
-    overflow: 'auto',
-    whiteSpace: 'nowrap',
-  };
-
-  const promptDollar = {
-    color: '#0EBE7F',
-    fontWeight: 700,
-    marginRight: '0.55rem',
-    userSelect: 'none',
-  };
-
-  const copyBtn = {
-    flex: '0 0 auto',
-    border: 'none',
-    borderLeft: '1px solid #2d2d30',
-    background: 'transparent',
-    color: copied ? '#0EBE7F' : '#9ca3af',
-    fontSize: '0.78rem',
-    fontWeight: 600,
-    letterSpacing: '0.04em',
-    textTransform: 'uppercase',
-    padding: '0 1rem',
-    cursor: 'pointer',
-    transition: 'color 120ms ease',
-  };
-
-  const footer = {
-    display: 'flex',
-    alignItems: 'center',
-    justifyContent: 'space-between',
-    gap: '0.75rem',
-    flexWrap: 'wrap',
-    fontSize: '0.88rem',
-    color: 'var(--ifm-color-emphasis-700)',
-  };
-
-  const slashLine = {
-    display: 'flex',
-    alignItems: 'center',
-    gap: '0.45rem',
-    flexWrap: 'wrap',
-  };
-
-  const slashCmd = {
-    fontFamily: 'var(--ifm-font-family-monospace, ui-monospace, SFMono-Regular, monospace)',
-    fontSize: '0.85rem',
-    fontWeight: 600,
-    padding: '2px 8px',
-    borderRadius: '4px',
-    background: 'var(--ifm-code-background, rgba(20, 163, 139, 0.10))',
-    border: '1px solid var(--ifm-color-emphasis-300)',
-    color: 'var(--ifm-color-content)',
-    whiteSpace: 'nowrap',
-  };
-
-  const githubLink = {
-    color: 'var(--ifm-color-primary, #14A38B)',
-    textDecoration: 'none',
-    fontWeight: 600,
-    display: 'inline-flex',
-    alignItems: 'center',
-    gap: '0.35rem',
-    whiteSpace: 'nowrap',
-  };
-
-  // ── icons ─────────────────────────────────────────────────────────────
-  const boltIcon = (
-    <svg width="16" height="16" viewBox="0 0 24 24" fill="none"
-      stroke="currentColor" strokeWidth="2.5"
-      strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
-      <polygon points="13 2 3 14 12 14 11 22 21 10 12 10 13 2" />
-    </svg>
-  );
-
-  const ghIcon = (
-    <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
-      <path d="M12 .5C5.73.5.5 5.73.5 12c0 5.08 3.29 9.39 7.86 10.91.58.11.79-.25.79-.55 0-.27-.01-1.18-.02-2.14-3.2.7-3.88-1.36-3.88-1.36-.52-1.32-1.27-1.67-1.27-1.67-1.04-.71.08-.7.08-.7 1.15.08 1.76 1.18 1.76 1.18 1.02 1.74 2.68 1.24 3.34.95.1-.74.4-1.24.72-1.53-2.55-.29-5.24-1.28-5.24-5.69 0-1.26.45-2.29 1.18-3.1-.12-.29-.51-1.46.11-3.04 0 0 .96-.31 3.15 1.18a10.97 10.97 0 0 1 5.74 0c2.19-1.49 3.15-1.18 3.15-1.18.62 1.58.23 2.75.11 3.04.73.81 1.18 1.84 1.18 3.1 0 4.42-2.69 5.4-5.25 5.69.41.36.78 1.07.78 2.16 0 1.56-.01 2.81-.01 3.19 0 .31.21.67.8.55C20.21 21.39 23.5 17.08 23.5 12 23.5 5.73 18.27.5 12 .5z"/>
-    </svg>
-  );
-
   return (
-    <div style={card}>
-      <div style={accentBar} aria-hidden="true" />
-
-      <div style={header}>
-        <div style={titleWrap}>
-          <div style={iconBox}>{boltIcon}</div>
-          <h3 style={titleText}>Let an agent scaffold this for you</h3>
-        </div>
-        <a
-          href={REPO_URL}
-          target="_blank"
-          rel="noopener noreferrer"
-          aria-label="View skill stats and source on GitHub"
-        >
-          <img src={BADGE_URL} alt="Skills count" style={badgeImg} />
-        </a>
-      </div>
-
-      <p style={subcopy}>
-        Install the <strong>TurboDocx Quickstart Skill</strong> and let Claude
-        Code, Cursor, Copilot, Codex, or any agent that speaks the{' '}
-        <a href="https://agentskills.io" target="_blank" rel="noopener noreferrer">
-          Agent Skills
-        </a>{' '}
-        standard install the SDK, wire routes into your app, and write a working{' '}
-        {product} integration end-to-end.
-      </p>
-
-      <div style={codeBlock}>
-        <span style={codeText}>
-          <span style={promptDollar}>$</span>{INSTALL_CMD}
+    <div className={styles.wrap}>
+      <div className={styles.pitch}>
+        <span className={styles.badge}>
+          <BoltIcon /> Agent Skill
         </span>
-        <button
-          type="button"
-          onClick={copyInstall}
-          style={copyBtn}
-          onMouseOver={(e) => { if (!copied) e.currentTarget.style.color = '#0EBE7F'; }}
-          onMouseOut={(e) => { if (!copied) e.currentTarget.style.color = '#9ca3af'; }}
-          aria-label="Copy install command"
-        >
-          {copied ? 'Copied' : 'Copy'}
-        </button>
+        <h3 className={styles.heading}>Let an agent scaffold this for you</h3>
+        <p className={styles.sub}>
+          Install the <strong>TurboDocx Quickstart Skill</strong> and let Claude
+          Code, Cursor, Copilot, Codex, or any agent that speaks the{' '}
+          <a href="https://agentskills.io" target="_blank" rel="noopener noreferrer">
+            Agent Skills
+          </a>{' '}
+          standard install the SDK, wire it into your app, and write a working{' '}
+          {product} integration end-to-end.
+        </p>
+        <div className={styles.links}>
+          <a href={REPO_URL} target="_blank" rel="noopener noreferrer" aria-label="View skill stats on GitHub">
+            <img src={BADGE_URL} alt="Skill count" className={styles.badgeImg} />
+          </a>
+          <a href={REPO_URL} target="_blank" rel="noopener noreferrer" className={styles.github}>
+            <GitHubIcon />
+            <span>View on GitHub</span>
+          </a>
+        </div>
       </div>
 
-      <div style={footer}>
-        <div style={slashLine}>
-          <span>Then run</span>
-          <code style={slashCmd}>{command}</code>
-          <span>in your agent.</span>
+      <div className={styles.terminal}>
+        <div className={styles.bar}>
+          <span className={styles.dots}>
+            <span className={`${styles.dot} ${styles.red}`} />
+            <span className={`${styles.dot} ${styles.yellow}`} />
+            <span className={`${styles.dot} ${styles.green}`} />
+          </span>
+          <span className={styles.barTitle}>bash — turbodocx</span>
         </div>
-        <a
-          href={REPO_URL}
-          target="_blank"
-          rel="noopener noreferrer"
-          style={githubLink}
-        >
-          {ghIcon}
-          <span>View on GitHub</span>
-        </a>
+        <div className={styles.body}>
+          <div className={styles.line}>
+            <code className={styles.cmd}>
+              <span className={styles.prompt}>$</span>
+              {INSTALL_CMD}
+            </code>
+            <button
+              type="button"
+              className={`${styles.copyBtn} ${copied ? styles.copied : ''}`}
+              onClick={copyInstall}
+              aria-label="Copy install command"
+            >
+              <CopyIcon copied={copied} />
+              {copied ? 'Copied' : 'Copy'}
+            </button>
+          </div>
+          <span className={styles.comment}># then, inside your agent:</span>
+          <code className={styles.cmd}>
+            <span className={styles.agentPrompt}>›</span>
+            {command}
+          </code>
+        </div>
       </div>
     </div>
   );

--- a/src/components/QuickstartSkillNudge.module.css
+++ b/src/components/QuickstartSkillNudge.module.css
@@ -1,0 +1,247 @@
+/* Developer-flavored "let an agent scaffold this" plug for the TurboDocx
+   Quickstart Agent Skill. Rendered at the top of every SDK page. */
+
+.wrap {
+  --qs-accent: #2b579a; /* brand primary */
+  --qs-term-bg: #0b1020;
+  --qs-term-fg: #e6edf3;
+  --qs-term-muted: #8b98b0;
+  --qs-prompt: #51cf66;
+
+  display: grid;
+  grid-template-columns: 1fr 1.15fr;
+  gap: 1.25rem;
+  align-items: center;
+  margin: 0 0 2rem;
+  padding: 1.25rem 1.35rem;
+  border-radius: 14px;
+  border: 1px solid var(--ifm-color-emphasis-200);
+  background:
+    radial-gradient(120% 140% at 0% 0%, rgba(43, 87, 154, 0.08), transparent 60%),
+    var(--ifm-background-surface-color);
+  position: relative;
+  overflow: hidden;
+}
+
+.wrap::before {
+  content: '';
+  position: absolute;
+  inset: 0 0 auto 0;
+  height: 3px;
+  background: linear-gradient(90deg, var(--qs-accent), #51cf66 70%, transparent);
+  opacity: 0.9;
+}
+
+[data-theme='dark'] .wrap {
+  border-color: var(--ifm-color-emphasis-300);
+}
+
+/* ---- left: pitch ---- */
+.badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  font-size: 0.72rem;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--qs-accent);
+  background: rgba(43, 87, 154, 0.1);
+  border: 1px solid rgba(43, 87, 154, 0.22);
+  padding: 0.22rem 0.55rem;
+  border-radius: 999px;
+}
+
+[data-theme='dark'] .badge {
+  color: #8fb2e8;
+  background: rgba(43, 87, 154, 0.18);
+  border-color: rgba(143, 178, 232, 0.28);
+}
+
+.bolt {
+  width: 0.85em;
+  height: 0.85em;
+}
+
+.heading {
+  margin: 0.6rem 0 0.35rem;
+  font-size: 1.2rem;
+  font-weight: 700;
+  line-height: 1.2;
+  letter-spacing: -0.01em;
+}
+
+.sub {
+  margin: 0 0 0.9rem;
+  font-size: 0.92rem;
+  line-height: 1.5;
+  color: var(--ifm-color-emphasis-700);
+}
+
+.sub a {
+  font-weight: 600;
+}
+
+.links {
+  display: flex;
+  align-items: center;
+  gap: 0.85rem;
+  flex-wrap: wrap;
+}
+
+.badgeImg {
+  height: 22px;
+  width: auto;
+  vertical-align: middle;
+  display: block;
+}
+
+.github {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: var(--qs-accent);
+  text-decoration: none;
+  white-space: nowrap;
+}
+
+.github:hover {
+  text-decoration: underline;
+  text-underline-offset: 2px;
+}
+
+[data-theme='dark'] .github {
+  color: #8fb2e8;
+}
+
+.ghIcon {
+  width: 1em;
+  height: 1em;
+}
+
+/* ---- right: terminal ---- */
+.terminal {
+  border-radius: 10px;
+  overflow: hidden;
+  background: var(--qs-term-bg);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  box-shadow: 0 18px 40px -20px rgba(11, 16, 32, 0.7);
+  font-family: var(--ifm-font-family-monospace);
+}
+
+.bar {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.55rem 0.75rem;
+  background: rgba(255, 255, 255, 0.04);
+  border-bottom: 1px solid rgba(255, 255, 255, 0.06);
+}
+
+.dots {
+  display: flex;
+  gap: 0.4rem;
+}
+
+.dot {
+  width: 11px;
+  height: 11px;
+  border-radius: 50%;
+}
+.red { background: #ff5f56; }
+.yellow { background: #ffbd2e; }
+.green { background: #27c93f; }
+
+.barTitle {
+  margin-left: auto;
+  font-size: 0.72rem;
+  color: var(--qs-term-muted);
+  letter-spacing: 0.03em;
+}
+
+.body {
+  padding: 0.85rem 1rem;
+}
+
+.line {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.cmd {
+  flex: 1;
+  margin: 0;
+  padding: 0;
+  border: 0;
+  background: none !important;
+  color: var(--qs-term-fg) !important;
+  font-size: 0.9rem;
+  white-space: nowrap;
+  overflow-x: auto;
+  scrollbar-width: none;
+}
+.cmd::-webkit-scrollbar { display: none; }
+
+.prompt {
+  color: var(--qs-prompt);
+  user-select: none;
+  margin-right: 0.5rem;
+  font-weight: 700;
+}
+
+.comment {
+  display: block;
+  margin: 0.7rem 0 0.15rem;
+  font-size: 0.82rem;
+  color: var(--qs-term-muted);
+}
+
+.agentPrompt {
+  color: #8fb2e8;
+  user-select: none;
+  margin-right: 0.5rem;
+  font-weight: 700;
+}
+
+.copyBtn {
+  flex-shrink: 0;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  font-family: var(--ifm-font-family-base);
+  font-size: 0.78rem;
+  font-weight: 600;
+  color: var(--qs-term-fg);
+  background: rgba(255, 255, 255, 0.08);
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: 7px;
+  padding: 0.35rem 0.6rem;
+  cursor: pointer;
+  transition: background 0.15s ease, border-color 0.15s ease, color 0.15s ease;
+}
+
+.copyBtn:hover {
+  background: rgba(255, 255, 255, 0.14);
+  border-color: rgba(255, 255, 255, 0.2);
+}
+
+.copyBtn.copied {
+  color: #27c93f;
+  border-color: rgba(39, 201, 63, 0.4);
+  background: rgba(39, 201, 63, 0.12);
+}
+
+.copyIcon {
+  width: 0.95em;
+  height: 0.95em;
+}
+
+@media (max-width: 768px) {
+  .wrap {
+    grid-template-columns: 1fr;
+    gap: 1rem;
+  }
+}

--- a/src/components/QuickstartSkillNudge.module.css
+++ b/src/components/QuickstartSkillNudge.module.css
@@ -244,4 +244,17 @@
     grid-template-columns: 1fr;
     gap: 1rem;
   }
+
+  /* let the command wrap instead of scrolling/clipping on narrow screens */
+  .line {
+    align-items: flex-start;
+    flex-wrap: wrap;
+  }
+
+  .cmd {
+    white-space: normal;
+    overflow-wrap: anywhere;
+    word-break: break-word;
+    font-size: 0.85rem;
+  }
 }


### PR DESCRIPTION
## What

Reworks the top-of-page **QuickstartSkillNudge** agent-skill plug into a developer-flavored **terminal window** card:

- Window chrome with macOS traffic-light dots and a `bash — turbodocx` title
- Green `$` prompt + the `npx skills add TurboDocx/quickstart` install command with a copy button (clipboard + insecure-context fallback)
- A second agent-prompt line (`›`) showing the page's slash command (e.g. `/turbodocx-sdk turbosign`)
- Left column: "Agent Skill" pill badge, headline, product-specific copy, the live skills.sh count badge, and a prominent **View on GitHub** link
- Brand-blue accent, light/dark aware via Docusaurus CSS vars, single-column on mobile

## Scope / risk

- Keeps the component **name** and `command` / `product` **props** unchanged, so **all 19 SDK pages render the new look with zero page edits**.
- Styling moved from inline styles into a CSS module (`QuickstartSkillNudge.module.css`).
- `npm run build` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)