### PR TITLE
docs: TurboQuote online payments (setup guide + JS SDK)

### DIFF
--- a/docs/SDKs/quote-javascript.md
+++ b/docs/SDKs/quote-javascript.md
@@ -696,6 +696,61 @@ const { results } = await TurboQuote.listTypes({
 });
 ```
 
+### Payments
+
+Collect payment for a quote online. The seller connects a payment provider once (Stripe Connect today) and funds are deposited directly to their account. See the [Setting Up Online Payments](../TurboQuote/Setting%20Up%20Online%20Payments.md) guide for the one-time connection.
+
+#### createPaymentLink
+
+Create a hosted pay link for a quote. Returns the checkout URL to send the buyer to and a stable `paymentId`. Requires the org to have a connected provider that can charge (see `getPaymentConnectionStatus`).
+
+```typescript
+const { checkoutUrl, paymentId } = await TurboQuote.createPaymentLink('quote-uuid', {
+  buyerEmail: 'buyer@example.com', // optional; falls back to the quote's contact
+});
+// Send checkoutUrl to the buyer; they pay on a secure, provider-hosted page.
+```
+
+#### getPaymentStatus
+
+Get a quote's current payment status (the latest payment), or `status: 'none'` if unpaid. Poll this, or prefer the `quote.payment.succeeded` webhook below.
+
+```typescript
+const payment = await TurboQuote.getPaymentStatus('quote-uuid');
+// payment.status: 'none' | 'pending' | 'partial' | 'paid' | 'failed' | 'overdue'
+// payment.amountDueToday, payment.currency, payment.paymentId, payment.checkoutId
+```
+
+#### getPaymentConnectionStatus
+
+Check whether the org is set up to collect, plus the active provider's capabilities. Use it to gate "request payment" UI before creating links.
+
+```typescript
+const conn = await TurboQuote.getPaymentConnectionStatus();
+// conn.connected, conn.chargesEnabled, conn.payoutsEnabled
+// conn.capabilities.supportsReferenceMetadata / supportsWebhookEvents / supportsSubscriptions / supportsCustomerPortal
+```
+
+> **Provider capabilities.** Not every payment provider supports every optional feature (rich metadata, subscriptions, a buyer portal). `capabilities` tells you what the org's provider supports. Payment **status** is always reliable regardless — it never depends on optional features.
+
+#### Webhook: `quote.payment.succeeded`
+
+Rather than polling, subscribe to the TurboDocx-native `quote.payment.succeeded` event (provider-agnostic — the same whether the seller is on Stripe or a future provider). Verify it with the shared `verifyWebhookSignature` helper (see the [TurboWebhooks SDK](./webhooks-javascript.md)). Payload `data`:
+
+```typescript
+{
+  quote_id: string;          // TurboQuote UUID
+  quote_number: string | null; // friendly number, e.g. "Q-2026-00001"
+  quote_name: string | null;
+  payment_id: string;
+  status: 'paid';
+  amount: number | null;
+  currency: string | null;
+  provider: string | null;   // e.g. "stripe_connect"
+  paid_at: string;           // ISO timestamp
+}
+```
+
 ---
 
 ## TypeScript Types

--- a/docs/TurboQuote/Linking Products to Your Payment Account.md
+++ b/docs/TurboQuote/Linking Products to Your Payment Account.md
@@ -1,0 +1,108 @@
+---
+title: Linking Products to Your Payment Account
+sidebar_position: 4
+description: Link your TurboQuote catalog products to the products in your connected payment account (Stripe), or import existing payment-account products into your catalog — so checkout reuses the same products and prices instead of creating new ones every time.
+keywords:
+  - turboquote
+  - link product
+  - import product
+  - stripe product
+  - stripe price
+  - product catalog
+  - payment account
+  - catalog sync
+  - reuse price
+  - online payments
+  - TurboDocx
+---
+
+# Linking Products to Your Payment Account
+
+Once you've [connected a payment account](./Setting%20Up%20Online%20Payments.md) to TurboQuote, you can connect your TurboQuote catalog products to the products that already live in that account. This keeps a single, tidy product list on both sides: when a customer pays a quote, checkout **reuses** the matching product and price in your payment account instead of creating a brand-new one each time.
+
+## What You'll Accomplish
+
+By the end of this guide you will be able to:
+
+- See, at a glance, which of your catalog products are linked to your payment account.
+- **Link** a TurboQuote product to an existing product in your payment account.
+- **Import** products you already have in your payment account into your TurboQuote catalog.
+- Understand what happens when you change a product or price directly in your payment account.
+
+:::info Before you start
+You need a connected payment account that is enabled for charges. If you haven't set that up yet, follow [Setting Up Online Payments](./Setting%20Up%20Online%20Payments.md) first. Until a payment account is connected, the product catalog shows a gentle prompt to connect one — the linking tools appear only after you're connected.
+:::
+
+## Why Link Products?
+
+When you collect payment on a quote, TurboQuote needs a product and a price in your payment account to charge against. If a catalog product isn't linked, TurboQuote creates a new product and price in your account on the fly. That works, but over time it can clutter your payment account with duplicates.
+
+**Linking** tells TurboQuote "this catalog product *is* that product in my payment account." From then on, checkout reuses it — no duplicates, and your payment-account reports stay clean and consolidated.
+
+## Reading the Link Status
+
+On the **Products** page (TurboQuote → Settings → Products), each product card shows a small status chip once your payment account is connected:
+
+| Chip | Meaning |
+|------|---------|
+| **Link to Stripe** (grey) | Not linked yet. Charging this product will create a new product/price in your payment account. Click to link it to an existing one. |
+| **Linked: _name_** (green) | Linked to a product in your payment account. Checkout reuses it. |
+| **Sync issue** (amber) | The linked product was changed or removed in your payment account. Click to re-link it. |
+
+Click any chip to open the link dialog.
+
+## Linking a Product
+
+1. Go to **TurboQuote → Settings → Products**.
+2. Find the product you want to link and click its **Link to Stripe** chip.
+3. In the dialog, search your payment-account products and pick the one that matches.
+   - Products already linked to a *different* catalog product are shown greyed out — each payment-account product can be linked to only one catalog product.
+4. Click **Link**. The chip turns green and shows the linked product's name.
+
+To **change or remove** a link, click the green **Linked** chip:
+
+- **Change** opens the picker again so you can point the catalog product at a different payment-account product.
+- **Unlink** disconnects them. Your payment-account product is left untouched — only TurboQuote's link is removed. After unlinking, charging this product will again create a new product/price.
+
+## Importing Products from Your Payment Account
+
+If you already have a catalog of products in your payment account, you can pull them into TurboQuote instead of re-typing them.
+
+1. On the **Products** page, click **Import from Stripe** (top right; visible once your payment account is connected).
+2. Choose the **category** the imported products should be filed under.
+3. Check the products you want to import. Products already in your TurboQuote catalog are hidden — you only see ones you don't have yet.
+4. Click **Import**. TurboQuote creates a catalog product for each one — copying the name, description, price, and billing frequency — and links it automatically.
+
+:::tip Multiple prices
+A payment-account product can have more than one price. TurboQuote seeds the new catalog product's price from the product's **default price** (or the first usable one) and links every compatible price so checkout can reuse them. If a product has an unusual billing cadence TurboQuote doesn't support (for example, weekly), that price is skipped — you can set a price on the product afterward.
+:::
+
+## What Happens If I Change a Product or Price in My Payment Account?
+
+TurboQuote keeps your links honest automatically:
+
+- **You rename a product** in your payment account → nothing breaks. TurboQuote always shows the current name when you open the picker.
+- **You archive or delete a linked product** → TurboQuote notices (via a secure webhook) and marks the catalog product with a **Sync issue** chip. The next time you collect payment on it, TurboQuote creates a fresh product so the sale never fails. Re-link it to a current product whenever you like.
+- **You change a price** → because prices can't be edited in place, your payment provider creates a *new* price and retires the old one. TurboQuote handles this transparently: it always charges against a live price, creating one if the old one was retired.
+
+In short: you never have to babysit the link. Sales keep working, and a **Sync issue** chip is just a friendly nudge to re-link when convenient.
+
+## Frequently Asked Questions
+
+**Does linking change anything in my payment account?**
+No. Linking and unlinking only affect TurboQuote's internal mapping. Your payment-account products and prices are never modified or deleted by TurboQuote.
+
+**Can I link one payment-account product to several catalog products?**
+No — each payment-account product links to a single catalog product, so reporting stays unambiguous. You'll see already-linked products greyed out in the picker.
+
+**Do I have to link my products?**
+No. Linking is optional and purely for keeping your payment account tidy. Unlinked products still charge correctly — TurboQuote just creates the product/price for them at checkout.
+
+**Is this Stripe-only?**
+The linking and import tools are built to work with any payment vendor TurboQuote supports. Stripe is the first; the same flow will apply as more vendors are added.
+
+## Related Articles
+
+- [Setting Up Online Payments](./Setting%20Up%20Online%20Payments.md)
+- [Adding a New Product](./Adding%20a%20New%20Product.md)
+- [Creating a New Quote](./Creating%20a%20New%20Quote.md)

--- a/docs/TurboQuote/Setting Up Online Payments.md
+++ b/docs/TurboQuote/Setting Up Online Payments.md
@@ -1,0 +1,117 @@
+---
+title: Setting Up Online Payments
+sidebar_position: 3
+description: Connect a Stripe account to TurboQuote so your customers can pay quotes online by card, ACH, or recurring subscription. Funds are deposited directly to your account.
+keywords:
+  - turboquote
+  - online payments
+  - stripe connect
+  - collect payment
+  - pay quote online
+  - card payment
+  - ACH
+  - recurring billing
+  - subscription
+  - TurboDocx
+---
+
+# Setting Up Online Payments with Stripe
+
+This guide walks you through connecting a Stripe account to TurboQuote so your customers can pay their quotes online. Once connected, every quote can carry a secure "Pay" link, payments are collected directly into **your** Stripe account, and TurboQuote keeps each quote's payment status up to date automatically.
+
+## What You'll Accomplish
+
+By the end of this guide you will have:
+
+- Connected your organization's Stripe account to TurboQuote.
+- Completed Stripe's onboarding so your account is enabled for charges and payouts.
+- Confirmed your "Account Readiness" shows you're fully set up to collect payments.
+- Understood how your customers pay a quote and how payment status is tracked.
+
+:::tip Quick Start Promise
+If you already have a Stripe account, connecting takes just a few minutes. You'll be redirected to Stripe to confirm a few business details, then returned to TurboQuote ready to get paid. Funds always go directly to your own Stripe account.
+:::
+
+## Before You Begin
+
+You'll need:
+
+- **Admin access** to your TurboDocx organization (only admins can connect a payment provider).
+- A **Stripe account**, or the details to create one during onboarding (business name and address, a bank account for payouts, and an authorized representative's identity information).
+
+:::note
+Your customers never need a TurboDocx or Stripe account to pay — they pay on a secure, Stripe-hosted checkout page.
+:::
+
+## Step 1: Open Payment Settings in TurboQuote
+
+From TurboQuote, navigate to **Settings → Payments**. This opens the **Payment Settings** page, where you can connect a payment provider so buyers can pay quotes online.
+
+## Step 2: Review the Stripe Connect Option
+
+On the Payment Settings page you'll see the **Stripe Connect** card. It lists what you'll be able to accept once connected, including:
+
+- Credit & debit cards
+- ACH bank transfers
+- Automatic payouts
+- Subscription (recurring) billing
+- 3D Secure customer authentication
+
+The card's status shows **Not Connected** until you finish setup. (You'll also see **Alternative Payments** and **FlexPoint** listed as "Coming soon" — additional payment options planned for the future.)
+
+## Step 3: Start Connecting Your Stripe Account
+
+Click **Connect Stripe Account**. TurboQuote prepares your connected account and redirects your browser to Stripe's secure onboarding flow.
+
+## Step 4: Complete Stripe's Onboarding
+
+On Stripe's hosted onboarding screens, confirm the details Stripe needs to enable payments for your account. Typically this includes:
+
+- Your **business type** and details (name, address, website, industry).
+- The **authorized representative's** identity information.
+- A **bank account** for receiving payouts.
+- Accepting Stripe's terms of service.
+
+Work through each screen and submit. Stripe handles all verification — TurboDocx never sees or stores your bank details or identity documents.
+
+## Step 5: Return to TurboQuote
+
+When you finish (or exit) Stripe's onboarding, Stripe returns you to the TurboQuote **Payment Settings** page. TurboQuote re-reads your account's status and updates the **Account Readiness** meter.
+
+## Step 6: Confirm Your Account Readiness
+
+On the Payment Settings page, the Stripe Connect card now shows an **Account Readiness** meter with two checks:
+
+- **Charges** — your account can accept payments.
+- **Payouts** — your account can receive deposits.
+
+Possible states:
+
+- **Action Needed / Stripe is finishing your verification** — Stripe is still verifying your details, or a few onboarding items remain. Use **Finish Setup** to return to Stripe and complete any outstanding requirements. Verification can take a short while; check back shortly.
+- **Active — fully set up to collect payments** — both Charges and Payouts are enabled. You're ready to get paid.
+
+:::tip
+You can return to **Settings → Payments** at any time to check your status or open your Stripe **Dashboard** to manage payouts, view balances, and see transaction history.
+:::
+
+## Step 7: How Your Customers Pay
+
+Once your account is **Active**, a quote can be paid online:
+
+1. Your customer opens the quote's secure **Pay** page.
+2. They see a clear **payment timeline** — what's due today, and any recurring charges (with amounts and dates) for subscription-style quotes.
+3. They click **Confirm & Pay** and complete payment on Stripe's secure, hosted checkout (card details are entered directly with Stripe — the seller never sees the card number).
+
+## Step 8: Track Payment Status Automatically
+
+After a customer pays, TurboQuote updates the quote's payment status automatically — no manual reconciliation. A successful payment marks the quote as **paid**; failed or overdue payments are reflected too, so you always know where each quote stands. Funds settle into your connected Stripe account on your normal payout schedule.
+
+## Summary
+
+You connected your Stripe account to TurboQuote, completed Stripe's onboarding, and confirmed your account is **Active** for charges and payouts. Your customers can now pay quotes online by card, ACH, or recurring subscription, with funds deposited directly to your account and payment status tracked automatically.
+
+**Next steps:**
+
+- Create or open a quote and share its **Pay** link with your customer.
+- Visit your Stripe **Dashboard** (from Settings → Payments) to view balances and payouts.
+- Manage or revisit your connection any time under **Settings → Payments**.

--- a/docs/TurboQuote/Setting Up Online Payments.md
+++ b/docs/TurboQuote/Setting Up Online Payments.md
@@ -111,11 +111,27 @@ Payment happens **after** your customer signs the quote. To make sure no one is 
 
 In plain terms:
 
-- When you **send** the quote, TurboQuote takes a **snapshot** of the totals on it — one-time amounts, recurring amounts, tax, term, and currency. These are the exact figures printed on the PDF your customer signs.
-- When they go to pay (even days later), they're charged **from that snapshot** — the numbers on the document they signed.
-- Quotes are locked from edits once they're sent, so the document, the snapshot, and the amount charged always match. Your customer is never billed a different number than the one on the quote they signed.
+- When you **send** the quote, TurboQuote takes a **snapshot** of the totals on it — one-time amounts, recurring amounts, the tax rate, term, and currency. These are the exact figures printed on the PDF your customer signs.
+- When they go to pay (even days later), they're charged **from that snapshot** — the prices on the document they signed.
+- Quotes are locked from edits once they're sent, so the document, the snapshot, and the amount charged always match. Your customer is never billed different prices than the ones on the quote they signed.
 
 You don't have to do anything to turn this on — it happens automatically the moment a quote is sent.
+
+## How Tax Is Collected
+
+If your quote has a tax rate, TurboQuote collects that tax at checkout so the amount your customer pays matches the total on the quote — not just the pre-tax subtotal.
+
+- Your quote's **tax rate** (set on the quote) is applied at payment time. Your customer sees a clear **"Tax"** line on the secure checkout page, on top of the subtotal.
+- For **subscription** quotes, the same tax rate carries onto every future renewal invoice automatically — recurring charges stay taxed, not just the first payment.
+- Tax is collected into **your** account along with the sale (you're the merchant of record), so you remit it the same way you handle tax everywhere else.
+
+:::note On exact amounts
+The **prices** your customer signs are locked exactly (see above). The **tax** is the quoted rate applied at the moment of payment. On quotes with several billing lines, the tax total can differ by **a cent or two** from the figure printed on the PDF — this is normal rounding (each line is taxed and rounded individually). The subtotal your customer signs is always charged exactly.
+:::
+
+:::tip Where does the tax rate come from?
+TurboQuote uses the flat tax rate on the quote itself — there's no separate tax setup to configure. (Address-based automatic tax calculation is planned for a future release; when a quote uses it, the quote will say _"taxes are calculated during payment for applicable jurisdictions"_ instead of showing a fixed amount.)
+:::
 
 ## Step 8: Track Payment Status Automatically
 

--- a/docs/TurboQuote/Setting Up Online Payments.md
+++ b/docs/TurboQuote/Setting Up Online Payments.md
@@ -12,6 +12,9 @@ keywords:
   - ACH
   - recurring billing
   - subscription
+  - disconnect stripe
+  - payment activity log
+  - payment troubleshooting
   - TurboDocx
 ---
 
@@ -106,12 +109,61 @@ Once your account is **Active**, a quote can be paid online:
 
 After a customer pays, TurboQuote updates the quote's payment status automatically — no manual reconciliation. A successful payment marks the quote as **paid**; failed or overdue payments are reflected too, so you always know where each quote stands. Funds settle into your connected Stripe account on your normal payout schedule.
 
+## Step 9: Review Your Payment Activity
+
+Once connected, the Stripe Connect card includes a **Payment activity** log — a running, newest-first timeline of the key moments between TurboQuote and Stripe for your organization. Each entry shows what happened, the outcome, and when. You'll see events such as:
+
+- **Connected** — your payment account was connected.
+- **Checkout created** — a pay link was generated for a quote you sent.
+- **Payment succeeded** / **Payment failed** — the outcome of a customer's payment, as reported by Stripe.
+- **Subscription canceled** — a recurring payment lapsed or was canceled.
+- **Disconnected** — your payment account was disconnected.
+
+Use the **refresh** icon on the Payment activity panel to pull the latest entries. This log is your at-a-glance record of payment activity without leaving TurboQuote — a quick way to confirm a payment came through or to see when a pay link was created.
+
+## Troubleshooting Payments
+
+If payments aren't behaving as expected, the Payment Settings page gives you everything you need to self-diagnose before contacting support.
+
+- **Your connected account ID** is shown on the Stripe Connect card (for example, `acct_…`), with a copy button. This is the exact identifier Stripe support and the TurboDocx team use to look up your account — have it ready if you reach out.
+- Expand **Having trouble collecting payments?** to see a quick diagnostics panel:
+  - **Charges enabled** and **Payouts enabled** — whether your account can take payments and receive deposits.
+  - **Requirements due** — anything Stripe still needs from you (complete these in Stripe to enable payments).
+  - **Last checked** — when TurboQuote last read your status, plus a **Refresh status** button to re-check on demand. If you just finished verification in Stripe, click **Refresh status** to confirm your account is now active without reloading the page.
+- The **Payment activity** log (above) shows whether recent payments succeeded or failed.
+
+:::tip
+Most "I can't collect payments" issues are an incomplete Stripe onboarding — check **Requirements due** first, finish them in Stripe, then **Refresh status**.
+:::
+
+## Disconnecting Your Payment Account
+
+You can disconnect your payment provider at any time — for example, to switch accounts or pause online payments.
+
+1. On the Stripe Connect card, scroll to the bottom and click **Disconnect account**.
+2. A confirmation dialog explains what happens and shows the account you're disconnecting. Review it, then click **Disconnect**.
+
+**What disconnecting does:**
+
+- You **won't be able to collect online payment on new quotes** until you reconnect.
+- **Pay links you've already sent stay active** — customers can still complete those payments.
+- **Payments already collected are unaffected**, and funds already settled remain in your Stripe account.
+
+To start collecting again, return to **Settings → Payments** and connect an account as in Step 3. Reconnecting your original Stripe account links it right back.
+
+:::note
+Disconnecting only removes the connection between TurboQuote and your provider — it does not close or delete your Stripe account.
+:::
+
 ## Summary
 
 You connected your Stripe account to TurboQuote, completed Stripe's onboarding, and confirmed your account is **Active** for charges and payouts. Your customers can now pay quotes online by card, ACH, or recurring subscription, with funds deposited directly to your account and payment status tracked automatically.
+
+You also know how to review your **Payment activity** log, troubleshoot with the connected account ID + **Refresh status**, and **disconnect** your account when needed.
 
 **Next steps:**
 
 - Create or open a quote and share its **Pay** link with your customer.
 - Visit your Stripe **Dashboard** (from Settings → Payments) to view balances and payouts.
-- Manage or revisit your connection any time under **Settings → Payments**.
+- Check the **Payment activity** log under Settings → Payments to confirm payments and track activity.
+- Manage, disconnect, or revisit your connection any time under **Settings → Payments**.

--- a/docs/TurboQuote/Setting Up Online Payments.md
+++ b/docs/TurboQuote/Setting Up Online Payments.md
@@ -126,7 +126,7 @@ If your quote has a tax rate, TurboQuote collects that tax at checkout so the am
 - Tax is collected into **your** account along with the sale (you're the merchant of record), so you remit it the same way you handle tax everywhere else.
 
 :::note On exact amounts
-The **prices** your customer signs are locked exactly (see above). The **tax** is the quoted rate applied at the moment of payment. On quotes with several billing lines, the tax total can differ by **a cent or two** from the figure printed on the PDF — this is normal rounding (each line is taxed and rounded individually). The subtotal your customer signs is always charged exactly.
+The **prices** your customer signs are locked exactly (see above). The **tax** is the quoted rate applied at the moment of payment. On quotes with **more than one billing line**, the tax total can differ by **a cent or two** from the figure printed on the PDF — each line is taxed and rounded to the cent on its own, then added up, which can land a penny away from rounding the whole subtotal once. (For example, three $33.33 lines at 8.5% total $8.49 in tax line-by-line, versus $8.50 on the rounded-once subtotal.) The **subtotal** your customer signs is always charged exactly, and single-line quotes never drift.
 :::
 
 :::tip Where does the tax rate come from?

--- a/docs/TurboQuote/Setting Up Online Payments.md
+++ b/docs/TurboQuote/Setting Up Online Payments.md
@@ -105,6 +105,18 @@ Once your account is **Active**, a quote can be paid online:
 2. They see a clear **payment timeline** — what's due today, and any recurring charges (with amounts and dates) for subscription-style quotes.
 3. They click **Confirm & Pay** and complete payment on Stripe's secure, hosted checkout (card details are entered directly with Stripe — the seller never sees the card number).
 
+## Your Customer Pays Exactly What They Signed
+
+Payment happens **after** your customer signs the quote. To make sure no one is ever surprised at the payment step, TurboQuote **locks in the price the moment the quote is signed.**
+
+In plain terms:
+
+- When the customer signs, TurboQuote takes a **snapshot** of the totals on that quote — one-time amounts, recurring amounts, tax, term, and currency.
+- When they go to pay (even days later), they're charged **from that snapshot** — the exact figures they agreed to.
+- If anything about the quote or its products changes afterward, **the signed amount is what gets charged.** Your customer is never billed a different number than the one they put their signature on.
+
+You don't have to do anything to turn this on — it happens automatically the moment a quote is signed. (Quotes are also locked from edits once they're sent, so the signed total and the document always match.)
+
 ## Step 8: Track Payment Status Automatically
 
 After a customer pays, TurboQuote updates the quote's payment status automatically — no manual reconciliation. A successful payment marks the quote as **paid**; failed or overdue payments are reflected too, so you always know where each quote stands. Funds settle into your connected Stripe account on your normal payout schedule.

--- a/docs/TurboQuote/Setting Up Online Payments.md
+++ b/docs/TurboQuote/Setting Up Online Payments.md
@@ -105,17 +105,17 @@ Once your account is **Active**, a quote can be paid online:
 2. They see a clear **payment timeline** — what's due today, and any recurring charges (with amounts and dates) for subscription-style quotes.
 3. They click **Confirm & Pay** and complete payment on Stripe's secure, hosted checkout (card details are entered directly with Stripe — the seller never sees the card number).
 
-## Your Customer Pays Exactly What They Signed
+## Your Customer Pays Exactly What's on the Quote They Signed
 
-Payment happens **after** your customer signs the quote. To make sure no one is ever surprised at the payment step, TurboQuote **locks in the price the moment the quote is signed.**
+Payment happens **after** your customer signs the quote. To make sure no one is ever surprised at the payment step, TurboQuote **locks in the price the moment the quote is sent** — because that's when the PDF your customer reviews and signs is created.
 
 In plain terms:
 
-- When the customer signs, TurboQuote takes a **snapshot** of the totals on that quote — one-time amounts, recurring amounts, tax, term, and currency.
-- When they go to pay (even days later), they're charged **from that snapshot** — the exact figures they agreed to.
-- If anything about the quote or its products changes afterward, **the signed amount is what gets charged.** Your customer is never billed a different number than the one they put their signature on.
+- When you **send** the quote, TurboQuote takes a **snapshot** of the totals on it — one-time amounts, recurring amounts, tax, term, and currency. These are the exact figures printed on the PDF your customer signs.
+- When they go to pay (even days later), they're charged **from that snapshot** — the numbers on the document they signed.
+- Quotes are locked from edits once they're sent, so the document, the snapshot, and the amount charged always match. Your customer is never billed a different number than the one on the quote they signed.
 
-You don't have to do anything to turn this on — it happens automatically the moment a quote is signed. (Quotes are also locked from edits once they're sent, so the signed total and the document always match.)
+You don't have to do anything to turn this on — it happens automatically the moment a quote is sent.
 
 ## Step 8: Track Payment Status Automatically
 


### PR DESCRIPTION
## Summary
Documents the new TurboQuote online-payments feature.

- **User guide** `docs/TurboQuote/Setting Up Online Payments.md` — connect Stripe (hosted onboarding), confirm Account Readiness, how buyers pay, automatic status tracking, **"Your Customer Pays Exactly What's on the Quote They Signed"** (the payable snapshot), and a **"How Tax Is Collected"** section (the quote's tax rate applied at checkout, recurring renewals stay taxed, the per-line rounding caveat, and address-based automatic tax as a future option). Steps scaffolded **without screenshots** (to add).
- **Linking guide** `docs/TurboQuote/Linking Products to Your Payment Account.md` — link / import / reconcile catalog products with the payment vendor.
- **JS SDK** `docs/SDKs/quote-javascript.md` → **Payments** section: `createPaymentLink`, `getPaymentStatus`, `getPaymentConnectionStatus`, the `quote.payment.succeeded` webhook payload, the provider-capabilities note.

## Status
Backend + JS SDK implemented, unit-tested, and verified end-to-end live (create → pending → paid → outbound webhook delivered). The **tax** and **catalog-link** copy is written; fixed-tax checkout has unit coverage but its live Stripe behavior (rendered Tax line) is verified separately. Other 5 SDK languages + screenshots + API-reference pages to follow.

## Notes
Draft — pending screenshots and the cross-language SDK port.
