### PR TITLE
docs(wrike): add Wrike Table and Wrike Image how-to guides

### DIFF
--- a/docs/Integrations/Wrike/image-variable.md
+++ b/docs/Integrations/Wrike/image-variable.md
@@ -29,6 +29,10 @@ This is the image counterpart to the [Wrike Table](./table-variable.md) variable
 
 On your template's **Details** page, find the variable you want to turn into images, open its three-dot menu, and choose **Wrike Image**.
 
+<div style={{display: 'flex', justifyContent: 'center', alignItems: 'center', width: '600px', height: '400px', backgroundColor: '#f8f9fa', border: '2px dashed #dee2e6', borderRadius: '8px', margin: '20px auto', fontSize: '24px', fontWeight: 'bold', color: '#6c757d'}}>
+  Screenshots Coming Soon
+</div>
+
 ### Step 2: Choose which images to attach
 
 - **Attach all images**: every image attachment on the triggering task or folder is included.

--- a/docs/Integrations/Wrike/image-variable.md
+++ b/docs/Integrations/Wrike/image-variable.md
@@ -1,0 +1,61 @@
+---
+title: How to Add a Wrike Image
+sidebar_position: 7
+description: Turn a TurboDocx variable into images that the Wrike automation pulls from the triggering task or folder's attachments, with optional name filtering.
+keywords:
+  - wrike image
+  - wrike image variable
+  - wrike attachments
+  - wrike attachment images
+  - wrike document images
+---
+
+# How to Add a Wrike Image
+
+A **Wrike Image** variable pulls image attachments from the triggering Wrike task or folder into your document. When the Wrike automation runs, TurboDocx attaches the matching images into that variable's place in the template. You can attach all images, or filter them by file name.
+
+This is the image counterpart to the [Wrike Table](./table-variable.md) variable, and it reuses the same configuration flow.
+
+## Prerequisites
+
+- A template uploaded to TurboDocx with at least one variable that is on its own line (a rich-text variable, so injected images have room to render)
+- A connected Wrike account (see [Setting Up a Wrike Automation](./setting-up-automation.md))
+
+<br/>
+
+## Configure the image variable
+
+### Step 1: Open the variable menu
+
+On your template's **Details** page, find the variable you want to turn into images, open its three-dot menu, and choose **Wrike Image**.
+
+### Step 2: Choose which images to attach
+
+- **Attach all images**: every image attachment on the triggering task or folder is included.
+- **Filter by name**: include only attachments whose file name contains one of your terms. Enter terms comma-separated; matching is case-insensitive and matches on substrings (for example `logo, header` matches `company-logo.png` and `Header_2024.jpg`).
+
+### Step 3: Set optional limits
+
+- **Max images**: cap how many images are attached (up to 20).
+- **Empty state text**: text that renders when no matching images are found.
+
+### Step 4: Save
+
+Click **Save Changes** on the variable. The configuration is stored on the template.
+
+<br/>
+
+## What happens at generation time
+
+Images are injected by the Wrike automation when a document is generated, so a Wrike Image variable is **read-only** on the generation page (it shows an informational banner instead of an input). To enter content manually instead, use **Switch to manual input** on the generation page.
+
+## Notes and limits
+
+- **Image cap**: a maximum of 20 images are attached per variable.
+- **PowerPoint**: when generating a PowerPoint (PPTX) document, only PNG and JPEG attachments are injected.
+
+## Related
+
+- [How to Add a Wrike Table](./table-variable.md)
+- [How to Setup Static Field Mapping](./field-mapping.md)
+- [Setting Up a Wrike Automation](./setting-up-automation.md)

--- a/docs/Integrations/Wrike/index.md
+++ b/docs/Integrations/Wrike/index.md
@@ -73,6 +73,8 @@ The Wrike integration uses a **status-triggered automation workflow** that you c
 | [How to Setup E-Signature Automation](./signature-automation.md) | Generate documents and send them for e-signature automatically |
 | [How to Setup Static Field Mapping](./field-mapping.md) | Map Wrike custom fields (revenue, dates, etc.) directly to template variables |
 | [How to Setup AI Variable Configuration](./ai-variable.md) | Configure AI-driven variables that generate content from prompts during automation |
+| [How to Add a Wrike Table](./table-variable.md) | Turn a variable into a table of a folder or project's sub-items, with nesting and filtering |
+| [How to Add a Wrike Image](./image-variable.md) | Pull image attachments from the triggering task or folder into your document |
 | [How to Add Signature Anchors](./signature-anchors.md) | Configure signature anchor fields in your template for TurboSign |
 | [Troubleshooting and FAQ](./troubleshooting.md) | Common issues, solutions, and frequently asked questions |
 

--- a/docs/Integrations/Wrike/table-variable.md
+++ b/docs/Integrations/Wrike/table-variable.md
@@ -8,6 +8,8 @@ keywords:
   - wrike subtasks table
   - wrike nested rows
   - wrike table filter
+  - wrike table multiple filters
+  - wrike table and or conditions
   - wrike folder sub-items
 ---
 
@@ -56,13 +58,27 @@ Turn on **Expand nested sub-items** to recurse beneath the direct children. **Ma
 
 ### Step 5: Filter which sub-items appear (optional)
 
-Add a **Filter** to include only sub-items that match a condition. Pick a field, then an operator and value. The available operators adapt to the field you pick:
+Add a **Filter** to include only sub-items that match one or more conditions. Pick a field, then an operator and value. The available operators adapt to the field you pick:
 
 - **Item Type**: "is any of" / "is none of", choosing from the built-in Task, Folder, and Project types plus your Wrike custom item types.
 - **Date fields**: before, after, on, on or before, on or after, between, plus relative options (overdue, in the next N days, in the last N days).
 - **Other fields**: is set, is not set, is checked, is not checked, equals, not equals.
 
-The filter keeps a parent row whenever it, or any sub-item beneath it, matches.
+#### Combine multiple conditions
+
+Click **+ Add condition** to add another row to the filter (up to 10). When you have two or more conditions, a **Match all (AND) / any (OR)** selector appears:
+
+- **all (AND)**: a sub-item must satisfy *every* condition to appear.
+- **any (OR)**: a sub-item appears if it satisfies *at least one* condition.
+
+Each condition has its own field, operator, and value, and the remove (trash) icon next to a condition deletes just that row. For example, to list only the **milestones due in the next 30 days**, add two conditions combined with **all (AND)**:
+
+1. **Task Type** "is any of" **Milestone**
+2. **Due date** "is in the next" **30** days
+
+Milestone is a Wrike custom item type, so this condition needs a Wrike plan that includes custom item types (see [Notes and limits](#notes-and-limits) below). To exercise multiple conditions on any plan, use a built-in type instead, such as **Task Type** "is any of" **Folder** combined with a due-date condition.
+
+The filter keeps a parent row whenever it, or any sub-item beneath it, matches the conditions.
 
 When **Expand nested sub-items** is on, two extra options control how a match pulls in the rows around it:
 

--- a/docs/Integrations/Wrike/table-variable.md
+++ b/docs/Integrations/Wrike/table-variable.md
@@ -1,0 +1,86 @@
+---
+title: How to Add a Wrike Table
+sidebar_position: 7
+description: Turn a TurboDocx variable into a table that the Wrike automation fills with a folder or project's sub-items, with optional nesting and filtering.
+keywords:
+  - wrike table
+  - wrike table variable
+  - wrike subtasks table
+  - wrike nested rows
+  - wrike table filter
+  - wrike folder sub-items
+---
+
+# How to Add a Wrike Table
+
+A **Wrike Table** variable turns a single template variable into a table. When the Wrike automation runs, TurboDocx fills that table with the triggering folder or project's **sub-items** (its tasks, and its subfolders or subprojects), one row each. You choose which Wrike fields become the columns, how the rows are laid out, whether nested sub-items are expanded, and an optional filter that limits which sub-items appear.
+
+This is different from [Static Field Mapping](./field-mapping.md), which maps one Wrike field to one variable. A Wrike Table maps one variable to many rows.
+
+## Prerequisites
+
+- A template uploaded to TurboDocx with at least one variable that is on its own line (a rich-text variable, so the generated table has room to render)
+- A connected Wrike account (see [Setting Up a Wrike Automation](./setting-up-automation.md))
+
+<br/>
+
+## Configure the table
+
+### Step 1: Open the variable menu
+
+On your template's **Details** page, find the variable you want to turn into a table, open its three-dot menu, and choose **Wrike Table**. This opens the Wrike Table editor with a live preview.
+
+### Step 2: Add fields (columns)
+
+Each field is a **value source** plus a **label**:
+
+- **Value source**: the Wrike field whose value fills the cells (for example Title, Status, Due Date, Assignee, or any custom field).
+- **Label**: type your own column heading, or pick a field and use its name as the heading.
+
+Add as many fields as you need, and drag the handles to reorder them. To show each row's entity type (Task, Folder, or Project), add the built-in **Item Type** field as a column.
+
+### Step 3: Choose the layout
+
+- **Sub-items as rows** (default): each sub-item is a row, each field is a column.
+- **Sub-items as columns**: the table is transposed.
+
+You can also pick an optional **Sub-item header** field (for example Title) to label each sub-item along the other axis, and set **Empty state text** that renders when the trigger has no sub-items.
+
+### Step 4: Expand nested sub-items (optional)
+
+Turn on **Expand nested sub-items** to recurse beneath the direct children. **Max depth** controls how many nested levels are expanded (1 to 5). Each nested row is numbered hierarchically (1, 1.1, 1.1.1) and indented so the hierarchy reads cleanly. Nesting is available only in the rows layout.
+
+### Step 5: Filter which sub-items appear (optional)
+
+Add a **Filter** to include only sub-items that match a condition. Pick a field, then an operator and value. The available operators adapt to the field you pick:
+
+- **Item Type**: "is any of" / "is none of", choosing from the built-in Task, Folder, and Project types plus your Wrike custom item types.
+- **Date fields**: before, after, on, on or before, on or after, between, plus relative options (overdue, in the next N days, in the last N days).
+- **Other fields**: is set, is not set, is checked, is not checked, equals, not equals.
+
+The filter keeps a parent row whenever it, or any sub-item beneath it, matches.
+
+:::tip Matching a formatted value
+For **equals** / **not equals** on a number, currency, or percentage field, type the value exactly as it appears in the table cell, including the currency symbol and decimals. For example, a value shown as `$50,000.00` should be entered as `$50,000.00`, not `$50,000`.
+:::
+
+### Step 6: Save
+
+Click **Save Changes** on the variable. The table configuration is stored on the template.
+
+<br/>
+
+## What happens at generation time
+
+The table is built by the Wrike automation when a document is generated, so a Wrike Table variable is **read-only** on the generation page (it shows an informational banner instead of an input). There is nothing to fill in by hand. If you want to enter content manually instead, use **Switch to manual input** on the generation page.
+
+## Notes and limits
+
+- **Row cap**: a table renders at most 500 rows. If more sub-items qualify, the table shows the first 500 and notes how many were omitted.
+- **Plan entitlements**: Wrike custom item types and finance fields (such as Budget or Actual Cost) require a Wrike plan that includes them. If your plan does not, those fields are left blank and a custom item-type filter condition is skipped (the table is never silently emptied). The built-in Task, Folder, and Project types work on any plan.
+
+## Related
+
+- [How to Add a Wrike Image](./image-variable.md)
+- [How to Setup Static Field Mapping](./field-mapping.md)
+- [Setting Up a Wrike Automation](./setting-up-automation.md)

--- a/docs/Integrations/Wrike/table-variable.md
+++ b/docs/Integrations/Wrike/table-variable.md
@@ -64,6 +64,11 @@ Add a **Filter** to include only sub-items that match a condition. Pick a field,
 
 The filter keeps a parent row whenever it, or any sub-item beneath it, matches.
 
+When **Expand nested sub-items** is on, two extra options control how a match pulls in the rows around it:
+
+- **Show parent rows of matches** (on by default): keep the parent rows above a match, so a deeply nested match still reads in context. Turn this off to show only the matching rows themselves; a match whose parents are hidden moves up to the top level.
+- **Include all sub-items of matching rows** (off by default): when a row matches, also show everything nested beneath it, even if those sub-items don't match the filter. Use this to filter the top of your hierarchy and then bring each matching branch in whole.
+
 :::tip Matching a formatted value
 For **equals** / **not equals** on a number, currency, or percentage field, type the value exactly as it appears in the table cell, including the currency symbol and decimals. For example, a value shown as `$50,000.00` should be entered as `$50,000.00`, not `$50,000`.
 :::

--- a/docs/Integrations/Wrike/table-variable.md
+++ b/docs/Integrations/Wrike/table-variable.md
@@ -30,6 +30,10 @@ This is different from [Static Field Mapping](./field-mapping.md), which maps on
 
 On your template's **Details** page, find the variable you want to turn into a table, open its three-dot menu, and choose **Wrike Table**. This opens the Wrike Table editor with a live preview.
 
+<div style={{display: 'flex', justifyContent: 'center', alignItems: 'center', width: '600px', height: '400px', backgroundColor: '#f8f9fa', border: '2px dashed #dee2e6', borderRadius: '8px', margin: '20px auto', fontSize: '24px', fontWeight: 'bold', color: '#6c757d'}}>
+  Screenshots Coming Soon
+</div>
+
 ### Step 2: Add fields (columns)
 
 Each field is a **value source** plus a **label**:


### PR DESCRIPTION
## Description
Adds user-facing how-to guides for the two Wrike **integration-mode variable types** that had no documentation in the Wrike integration section:

- **How to Add a Wrike Table** (`table-variable.md`) — fields/columns, rows vs columns layout, nested sub-items with max depth, the filter operator families (item type / date / generic), generation-time read-only behavior, the 500-row cap, and plan-entitlement notes.
- **How to Add a Wrike Image** (`image-variable.md`) — attach-all vs filter-by-name, max images, empty-state text, and the 20-image / PPTX PNG-JPEG limits.

Both are linked from the Wrike integration index (`index.md`).

Naming follows the in-product menu items ("Wrike Table" / "Wrike Image").

## Notes
- Diátaxis: how-to guides (task-oriented) with a compact options/limits reference section, matching the existing Wrike section style.
- **Screenshots not yet included** — the existing Wrike pages are screenshot-heavy (`/img/wrike-integration/*`). These guides are text-only for now; images can be added in a follow-up. (Kept as a draft for that reason + review.)
- Related product work: backend Wrike Table part-two + the custom-field filter fix, frontend dialog. (RapidDocxBackend #1403 / RapidDocxFrontEnd #2081, merged to staging.)
