### PR TITLE
docs(sdk): document quote-number config methods

### DIFF
--- a/docs/SDKs/quote-go.md
+++ b/docs/SDKs/quote-go.md
@@ -322,6 +322,9 @@ config, err := qc.UpdateQuoteNumberConfig(ctx, &turbodocx.QuoteNumberFormat{
     StartNumber:  1000,     // >= 0
     ResetCadence: "never",  // "never" | "yearly" | "monthly"
 })
+if err != nil {
+    log.Fatal(err)
+}
 fmt.Println(config.Format.StartNumber)  // 1000
 ```
 

--- a/docs/SDKs/quote-go.md
+++ b/docs/SDKs/quote-go.md
@@ -290,6 +290,43 @@ quote, err := qc.RemovePriceBook(ctx, "quote-uuid")
 
 ---
 
+### Quote Numbering Configuration
+
+Customize the per-org quote number format: prefix, year/month tokens, separator, zero-padding, suffix, starting number, and reset cadence. Both methods are **admin only**; a non-admin API key receives a `403`.
+
+#### GetQuoteNumberConfig
+
+Fetches the org's current quote numbering format and the current per-period issued floor.
+
+```go
+config, err := qc.GetQuoteNumberConfig(ctx)
+if err != nil {
+    log.Fatal(err)
+}
+fmt.Println(config.Format.Prefix)   // e.g. "Q-"
+fmt.Println(config.CurrentFloor)    // the current per-period issued floor
+```
+
+#### UpdateQuoteNumberConfig
+
+Updates the numbering format. Pass the full format; all eight fields are sent.
+
+```go
+config, err := qc.UpdateQuoteNumberConfig(ctx, &turbodocx.QuoteNumberFormat{
+    Prefix:       "INV",
+    YearToken:    "none",  // "none" | "two" | "four"
+    MonthToken:   "off",   // "off" | "two"
+    Separator:    "-",
+    PadWidth:     4,        // 0–12
+    Suffix:       "",
+    StartNumber:  1000,     // >= 0
+    ResetCadence: "never",  // "never" | "yearly" | "monthly"
+})
+fmt.Println(config.Format.StartNumber)  // 1000
+```
+
+---
+
 ### Quote Status Transitions
 
 #### SendQuote

--- a/docs/SDKs/quote-java.md
+++ b/docs/SDKs/quote-java.md
@@ -389,13 +389,13 @@ Update the numbering format. All eight fields are sent.
 ```java
 QuoteNumberFormat format = new QuoteNumberFormat();
 format.setPrefix("INV");
-format.setYearToken("none");      // "none" | "two" | "four"
-format.setMonthToken("off");      // "off" | "two"
+format.setYearToken(QuoteNumberYearToken.NONE);        // NONE | TWO | FOUR
+format.setMonthToken(QuoteNumberMonthToken.OFF);       // OFF | TWO
 format.setSeparator("-");
-format.setPadWidth(4);            // 0–12
+format.setPadWidth(4);                                 // 0–12
 format.setSuffix("");
-format.setStartNumber(1000);      // >= 0
-format.setResetCadence("never");  // "never" | "yearly" | "monthly"
+format.setStartNumber(1000);                           // >= 0
+format.setResetCadence(QuoteNumberResetCadence.NEVER); // NEVER | YEARLY | MONTHLY
 
 QuoteNumberConfig config = tq.updateQuoteNumberConfig(format);
 System.out.println(config.getFormat().getStartNumber());  // 1000

--- a/docs/SDKs/quote-java.md
+++ b/docs/SDKs/quote-java.md
@@ -360,6 +360,49 @@ Files.write(Paths.get("quote.pdf"), pdf);
 
 ---
 
+### Quote Numbering Configuration
+
+Customize the per-org quote number format: prefix, year/month tokens, separator, zero-padding, suffix, starting number, and reset cadence. Both methods are **admin only**; a non-admin API key receives a `403`.
+
+#### `getQuoteNumberConfig`
+
+```java
+QuoteNumberConfig getQuoteNumberConfig()
+```
+
+Fetch the org's current quote numbering format and the current per-period issued floor.
+
+```java
+QuoteNumberConfig config = tq.getQuoteNumberConfig();
+System.out.println(config.getFormat().getPrefix());  // e.g. "Q-"
+System.out.println(config.getCurrentFloor());        // the current per-period issued floor
+```
+
+#### `updateQuoteNumberConfig`
+
+```java
+QuoteNumberConfig updateQuoteNumberConfig(QuoteNumberFormat format)
+```
+
+Update the numbering format. All eight fields are sent.
+
+```java
+QuoteNumberFormat format = new QuoteNumberFormat();
+format.setPrefix("INV");
+format.setYearToken("none");      // "none" | "two" | "four"
+format.setMonthToken("off");      // "off" | "two"
+format.setSeparator("-");
+format.setPadWidth(4);            // 0–12
+format.setSuffix("");
+format.setStartNumber(1000);      // >= 0
+format.setResetCadence("never");  // "never" | "yearly" | "monthly"
+
+QuoteNumberConfig config = tq.updateQuoteNumberConfig(format);
+System.out.println(config.getFormat().getStartNumber());  // 1000
+```
+
+---
+
 ### Quotes — Status Transitions
 
 #### `sendQuote`

--- a/docs/SDKs/quote-javascript.md
+++ b/docs/SDKs/quote-javascript.md
@@ -335,6 +335,40 @@ writeFileSync('quote.pdf', Buffer.from(pdf));
 
 ---
 
+### Quote Numbering Configuration
+
+Customize the per-org quote number format: prefix, year/month tokens, separator, zero-padding, suffix, starting number, and reset cadence. Both methods are **admin only**; a non-admin API key receives a `403`.
+
+#### getQuoteNumberConfig
+
+Fetch the org's current quote numbering format and the current per-period issued floor.
+
+```typescript
+const config = await TurboQuote.getQuoteNumberConfig();
+console.log(config.format.prefix);   // e.g. "Q-"
+console.log(config.currentFloor);    // the current per-period issued floor
+```
+
+#### updateQuoteNumberConfig
+
+Update the numbering format. Pass the full format object; all eight fields are required.
+
+```typescript
+const config = await TurboQuote.updateQuoteNumberConfig({
+  prefix: 'INV',
+  yearToken: 'none',      // 'none' | 'two' | 'four'
+  monthToken: 'off',      // 'off' | 'two'
+  separator: '-',
+  padWidth: 4,            // 0–12
+  suffix: '',
+  startNumber: 1000,      // >= 0
+  resetCadence: 'never',  // 'never' | 'yearly' | 'monthly'
+});
+console.log(config.format.startNumber);  // 1000
+```
+
+---
+
 ### Quote Status Transitions
 
 #### sendQuote

--- a/docs/SDKs/quote-php.md
+++ b/docs/SDKs/quote-php.md
@@ -324,6 +324,40 @@ $quote = TurboQuote::handleExpiredQuote('quote-uuid', new HandleExpiredQuoteRequ
 ));
 ```
 
+### Quote Numbering Configuration
+
+Customize the per-org quote number format: prefix, year/month tokens, separator, zero-padding, suffix, starting number, and reset cadence. Both methods are **admin only**; a non-admin API key receives a `403`.
+
+#### getQuoteNumberConfig
+
+Fetch the org's current quote numbering format and the current per-period issued floor.
+
+```php
+$config = TurboQuote::getQuoteNumberConfig();
+echo $config->format->prefix;    // e.g. "Q-"
+echo $config->currentFloor;      // the current per-period issued floor
+```
+
+#### updateQuoteNumberConfig
+
+Update the numbering format. All eight fields are sent.
+
+```php
+use TurboDocx\Types\Requests\Quote\QuoteNumberFormat;
+
+$config = TurboQuote::updateQuoteNumberConfig(new QuoteNumberFormat(
+    prefix: 'INV',
+    yearToken: 'none',      // 'none' | 'two' | 'four'
+    monthToken: 'off',      // 'off' | 'two'
+    separator: '-',
+    padWidth: 4,            // 0–12
+    suffix: '',
+    startNumber: 1000,      // >= 0
+    resetCadence: 'never',  // 'never' | 'yearly' | 'monthly'
+));
+echo $config->format->startNumber;  // 1000
+```
+
 ### Price Books on Quotes
 
 #### applyPriceBook

--- a/docs/SDKs/quote-php.md
+++ b/docs/SDKs/quote-php.md
@@ -343,7 +343,7 @@ echo $config->currentFloor;      // the current per-period issued floor
 Update the numbering format. All eight fields are sent.
 
 ```php
-use TurboDocx\Types\Requests\Quote\QuoteNumberFormat;
+use TurboDocx\Types\Quote\QuoteNumberFormat;
 
 $config = TurboQuote::updateQuoteNumberConfig(new QuoteNumberFormat(
     prefix: 'INV',

--- a/docs/SDKs/quote-python.md
+++ b/docs/SDKs/quote-python.md
@@ -262,6 +262,40 @@ with open("quote.pdf", "wb") as f:
 
 ---
 
+### Quote Numbering Configuration
+
+Customize the per-org quote number format: prefix, year/month tokens, separator, zero-padding, suffix, starting number, and reset cadence. Both methods are **admin only**; a non-admin API key receives a `403`.
+
+#### `get_quote_number_config`
+
+Fetch the org's current quote numbering format and the current per-period issued floor.
+
+```python
+config = await TurboQuote.get_quote_number_config()
+print(config["format"]["prefix"])   # e.g. "Q-"
+print(config["currentFloor"])       # the current per-period issued floor
+```
+
+#### `update_quote_number_config`
+
+Update the numbering format. Pass the full format object; all eight fields are required. Keys stay camelCase.
+
+```python
+config = await TurboQuote.update_quote_number_config({
+    "prefix": "INV",
+    "yearToken": "none",       # "none" | "two" | "four"
+    "monthToken": "off",       # "off" | "two"
+    "separator": "-",
+    "padWidth": 4,             # 0–12
+    "suffix": "",
+    "startNumber": 1000,       # >= 0
+    "resetCadence": "never",   # "never" | "yearly" | "monthly"
+})
+print(config["format"]["startNumber"])  # 1000
+```
+
+---
+
 ### Quote Status Transitions
 
 #### `send_quote`


### PR DESCRIPTION
## Related
Documents the new SDK quote-numbering config methods.
**Backend PR:** nicolasiscoding/RapidDocxBackend#1463
**Frontend PR:** nicolasiscoding/RapidDocxFrontEnd#2112
**SDK PR:** TurboDocx/SDK#37

## Description
Adds a "Quote numbering configuration" section to each TurboQuote SDK page (JavaScript, Python, Go, Java, PHP) documenting `getQuoteNumberConfig` / `updateQuoteNumberConfig` (idiomatic per language), with a fetch-then-update example using a custom format. Admin-only; lets an org customize the quote number prefix, tokens, padding, starting number, and reset cadence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
