### PR TITLE
docs(turbosign): email deliverability DKIM/DMARC/SPF FAQ

### DIFF
--- a/docs/TurboSign/Email Deliverability and DKIM DMARC.md
+++ b/docs/TurboSign/Email Deliverability and DKIM DMARC.md
@@ -1,118 +1,108 @@
 ---
 title: Email Deliverability (DKIM / DMARC / SPF)
 sidebar_position: 7
-description: Why TurboSign and TurboDocx emails can show DKIM, DMARC, or SPF failures when a recipient's security gateway (Avanan, Microsoft Safe Links, or similar) rewrites the message, and how to confirm and resolve it.
+description: How to diagnose and resolve DKIM, DMARC, or SPF failures on TurboDocx and TurboSign emails, including the common case where a security gateway rewrites the message in transit.
 keywords:
   - turbosign email deliverability
   - dkim failure
   - dmarc failure
   - spf softfail
   - body hash did not verify
-  - avanan
   - email security gateway
   - dkim signature
   - arc seal
-  - safe links
+  - email troubleshooting
 ---
 
 # Email Deliverability (DKIM / DMARC / SPF)
 
-TurboDocx sends email, including TurboSign signature requests and reminders, through an authenticated email delivery service. Occasionally a recipient reports that our messages fail DKIM or DMARC. In nearly every case the cause is a **recipient-side email security gateway that modifies the message after it has been signed** — not a problem with TurboDocx or DNS.
+TurboDocx emails, including TurboSign signature requests and reminders, are sent from an authenticated domain with DKIM, SPF, and DMARC in place. If a message shows a DKIM, DMARC, or SPF failure, this page walks you through what to check and how to resolve it.
 
-This page explains how to recognize, confirm, and resolve that situation.
+The most common cause is something modifying the email **in transit, after it was signed**, usually a security gateway between the sender and the inbox. The steps below help you confirm where it's happening and what to do about it.
 
-## Why does a TurboDocx email fail DKIM or DMARC?
+## What's happening
 
-A DKIM signature includes a cryptographic hash of the message body. The email is signed *before* it leaves our sending infrastructure. If anything downstream changes the signed body, the hash no longer matches and DKIM fails. Because DMARC relies on an aligned SPF **or** DKIM pass, DMARC can fail too.
+A DKIM signature includes a cryptographic hash of the message body. The email is signed before it leaves our infrastructure. If anything along the delivery path changes the body, even slightly, the hash no longer matches and DKIM fails. Because DMARC passes only when SPF or DKIM is aligned, DMARC can fail as a result.
 
-Security platforms commonly modify messages in transit by:
+Email security products often modify messages as they inspect them:
 
-- Rewriting URLs for click-time protection (the most common cause)
-- Inserting external-sender banners, warnings, or disclaimers
-- Sanitizing or re-encoding HTML / MIME
-- Inspecting or altering attachments
+- Rewriting links for click-time protection (the most common trigger)
+- Adding external-sender banners, warnings, or disclaimers
+- Sanitizing or re-encoding HTML and MIME
+- Inspecting or re-packaging attachments
 - Normalizing whitespace or line endings
 
-[Avanan](https://www.avanan.com/) (Check Point) routes mail through its own infrastructure and rewrites links depending on the recipient organization's policy. The same behavior occurs with other secure email gateways, anti-phishing products, and Microsoft Safe Links configurations.
+Products that do this include secure email gateways and anti-phishing platforms such as Avanan (Check Point), Mimecast, Proofpoint, and Microsoft Safe Links. The behavior depends on each organization's configured policy, so the same message can pass for one recipient and fail for another.
 
-## What do the failures look like?
+## Symptoms you might see
 
-A recipient may report any of these:
+- A message marked as failing DKIM or DMARC
+- A message quarantined, delayed, or flagged as suspicious
+- Headers containing `body hash did not verify`
+- SPF passing on first arrival but failing after the message is relayed
+- A message that delivers fine to one mailbox (for example Gmail) but fails at another
 
-- Message marked as failing DKIM or DMARC
-- Message quarantined, delayed, or flagged suspicious
-- Headers showing `body hash did not verify`
-- SPF passing on first arrival at Microsoft 365 but failing after a relay
-- Message delivers fine to Gmail but fails through Avanan
-- One or both DKIM signatures on the message failing at once
-
-Typical headers:
+A failing DKIM result in the headers typically looks like this:
 
 ```
 dkim=fail (body hash did not verify) header.d=sign.turbodocx.com
-dkim=fail (body hash did not verify) header.d=<sending provider>
 ```
 
-## Why does SPF also "softfail" sometimes?
+A message can carry more than one DKIM signature, and when the body is modified in transit they tend to fail together, so seeing two failures at once is expected and points to the same cause.
 
-When the gateway relays the message back to Microsoft 365, Microsoft runs SPF again. At that point the source IP belongs to the **security gateway**, not the original TurboDocx sender. Since the gateway is not an authorized TurboDocx sender, SPF can show a soft failure:
+## Why SPF can also "softfail"
+
+When a gateway inspects a message and then relays it onward, the receiving server runs SPF again. At that point the connecting IP belongs to the **gateway**, not the original sending infrastructure. Since that IP is not in the TurboDocx SPF record, SPF can report a soft failure:
 
 ```
-spf=softfail smtp.mailfrom=e.sign.turbodocx.com sender IP=<security gateway IP>
+spf=softfail smtp.mailfrom=e.sign.turbodocx.com sender IP=<gateway address>
 ```
 
-This does not mean the recipient's domain caused the failure, and **the gateway IP should not be added to TurboDocx's SPF record.**
+This is a side effect of the relay, not a DNS problem on the sending side. Don't add the gateway's IP to the TurboDocx SPF record. It isn't a TurboDocx sender, and adding it won't fix the underlying body-hash mismatch.
 
-## How do I confirm it's the recipient's gateway?
+## Troubleshooting steps
 
-1. **Compare against a direct mailbox.** Send the same type of message to Gmail or another mailbox that receives mail directly. A healthy result looks like:
+Work through these in order to pinpoint where the failure is introduced.
+
+1. **Send the same email to a directly delivered mailbox.** Use a mailbox that receives mail without a gateway in front of it (a personal Gmail address works well). A healthy result looks like:
 
    ```
    dkim=pass header.d=sign.turbodocx.com
-   dkim=pass header.d=<sending provider>
    spf=pass
    dmarc=pass
    ```
 
-   If it passes when delivered directly but fails only after the recipient's security platform processes it, the downstream platform is the cause.
+   If it passes here but fails at the affected mailbox, the difference is something in that mailbox's delivery path, typically a security gateway.
 
-2. **Read the pre-gateway result.** Look for an `Authentication-Results-Original` header (or similar). If SPF, DKIM, and DMARC passed *before* the gateway processed the message, TurboDocx authenticated correctly.
+2. **Compare the authentication results before and after the gateway.** Many platforms record the original result in a header such as `Authentication-Results-Original` (or an ARC chain). If SPF, DKIM, and DMARC passed *before* the gateway processed the message, the message was authenticated correctly and was altered afterward.
 
-3. **Temporarily bypass the policy.** Have the recipient's email admin exclude a test mailbox (or the TurboDocx app URL) from URL-rewriting / content-modification, then send a new message with a unique subject. If DKIM and DMARC pass, the policy modification is confirmed as the cause.
+3. **Test with the modifying policy temporarily off.** Ask the administrator of the affected environment to exclude a test mailbox (or the TurboDocx application URL) from URL rewriting and content modification, then resend with a unique subject. If DKIM and DMARC now pass, you've confirmed the policy as the cause.
 
-## How is it resolved?
+## How to resolve it
 
-**No TurboDocx-side change is normally required.** The fix is on the recipient side. Their email administrator can choose to:
+If the failure only appears after a gateway modifies the message, the sending configuration is working and the change is made on the receiving side. The administrator of the affected email environment has a few options:
 
-- Leave the policy as-is and rely on **ARC** or the platform's trusted-authentication handling. (ARC is designed to preserve original authentication results across an intermediary that modifies the message, though interoperability between platforms can be finicky.)
-- Exclude the TurboDocx application URL from click-time URL rewriting — for Avanan, this typically means excluding `app.turbodocx.com` from link rewriting.
-- Create a narrowly scoped exception for TurboDocx messages.
-- Confirm Microsoft 365 trusts the gateway's ARC seal.
-- Contact the security-platform vendor if messages are being incorrectly quarantined.
+- **Rely on ARC.** ARC is designed to carry the original authentication results across an intermediary that modifies a message, so a receiver that trusts the gateway's ARC seal can still treat the message as authenticated. Confirm the receiving platform is configured to trust that seal.
+- **Exclude the TurboDocx application URL from link rewriting.** For most gateways this means adding `app.turbodocx.com` to the link-rewriting exclusion list. This stops the body from being modified for those links. Because it also skips click-time inspection for them, treat it as a scoped exception rather than a blanket change.
+- **Create a narrowly scoped exception for TurboDocx messages** instead of disabling protection broadly.
+- **Contact the gateway vendor** if messages are being incorrectly quarantined or rejected despite a valid ARC chain.
 
-Any URL-rewriting exclusion reduces click-time inspection for those links, so the recipient's security administrator should evaluate it.
+## What not to do
 
-## What should we *not* do?
+- Don't loosen or disable DKIM and DMARC enforcement on the receiving side just to make the failure disappear. That hides the problem and weakens protection for all of your inbound mail, not just TurboDocx.
+- Don't read the domain in an SPF result as the domain being authenticated. After a relay it reflects the gateway, not the original sender.
 
-- ❌ Add the recipient's gateway IP to TurboDocx's SPF record
-- ❌ Replace working TurboDocx DKIM records
-- ❌ Disable DKIM or DMARC
-- ❌ Exclude an entire organization from email protection without a documented reason
-- ❌ Assume the domain shown in an SPF result is the domain being authenticated
+You don't need to change anything in TurboDocx's own DNS (SPF or DKIM records). Those are managed on the sending side and are working when the message passes at a directly delivered mailbox in step 1.
 
-## What information should I collect for escalation?
+## What to share if you contact support
 
-If you need to escalate, request from the recipient:
+If you've worked through the steps and still need help, include as much of the following as you can. It lets us pinpoint the cause quickly:
 
-- Complete message headers
-- Recipient email platform (e.g. Microsoft 365)
-- Email security product in use (e.g. Avanan)
-- Whether URL rewriting is enabled
-- Whether external banners / disclaimers are inserted
-- Final DKIM, SPF, DMARC, ARC, and composite-authentication results
-- Results of a comparison message sent to Gmail
-- Results of a temporary policy-bypass test
+- The complete message headers
+- The email platform and any security product in the delivery path
+- Whether link rewriting or external banners are enabled
+- The final DKIM, SPF, DMARC, and ARC results
+- The result of the same email sent to a directly delivered mailbox (step 1)
+- The result with the modifying policy temporarily off (step 3)
 
-## Bottom line
-
-If TurboDocx messages pass SPF, DKIM, and DMARC when delivered directly but fail after a recipient-side security service modifies the message, the cause is downstream message mutation — not the TurboDocx configuration. This is especially common in MSP-managed Microsoft 365 environments.
+If a TurboDocx email passes DKIM, SPF, and DMARC when delivered directly but fails only after a gateway modifies it, the cause is that in-transit change rather than the sending configuration, and the fix lives with the gateway or the receiving platform's handling of it.

--- a/docs/TurboSign/Email Deliverability and DKIM DMARC.md
+++ b/docs/TurboSign/Email Deliverability and DKIM DMARC.md
@@ -1,0 +1,118 @@
+---
+title: Email Deliverability (DKIM / DMARC / SPF)
+sidebar_position: 7
+description: Why TurboSign and TurboDocx emails can show DKIM, DMARC, or SPF failures when a recipient's security gateway (Avanan, Microsoft Safe Links, or similar) rewrites the message, and how to confirm and resolve it.
+keywords:
+  - turbosign email deliverability
+  - dkim failure
+  - dmarc failure
+  - spf softfail
+  - body hash did not verify
+  - avanan
+  - email security gateway
+  - amazon ses dkim
+  - arc seal
+  - safe links
+---
+
+# Email Deliverability (DKIM / DMARC / SPF)
+
+TurboDocx sends email (including TurboSign signature requests and reminders) through Amazon SES. Occasionally a recipient reports that our messages fail DKIM or DMARC. In nearly every case the cause is a **recipient-side email security gateway that modifies the message after SES has signed it** — not a problem with TurboDocx, SES, or DNS.
+
+This page explains how to recognize, confirm, and resolve that situation.
+
+## Why does a TurboDocx email fail DKIM or DMARC?
+
+A DKIM signature includes a cryptographic hash of the message body. Amazon SES signs the email *before* it leaves our infrastructure. If anything downstream changes the signed body, the hash no longer matches and DKIM fails. Because DMARC relies on an aligned SPF **or** DKIM pass, DMARC can fail too.
+
+Security platforms commonly modify messages in transit by:
+
+- Rewriting URLs for click-time protection (the most common cause)
+- Inserting external-sender banners, warnings, or disclaimers
+- Sanitizing or re-encoding HTML / MIME
+- Inspecting or altering attachments
+- Normalizing whitespace or line endings
+
+[Avanan](https://www.avanan.com/) (Check Point) routes mail through its own infrastructure and rewrites links depending on the recipient organization's policy. The same behavior occurs with other secure email gateways, anti-phishing products, and Microsoft Safe Links configurations.
+
+## What do the failures look like?
+
+A recipient may report any of these:
+
+- Message marked as failing DKIM or DMARC
+- Message quarantined, delayed, or flagged suspicious
+- Headers showing `body hash did not verify`
+- SPF passing on first arrival at Microsoft 365 but failing after a relay
+- Message delivers fine to Gmail but fails through Avanan
+- Both the TurboDocx and the Amazon SES DKIM signatures failing at once
+
+Typical headers:
+
+```
+dkim=fail (body hash did not verify) header.d=sign.turbodocx.com
+dkim=fail (body hash did not verify) header.d=amazonses.com
+```
+
+## Why does SPF also "softfail" sometimes?
+
+When the gateway relays the message back to Microsoft 365, Microsoft runs SPF again. At that point the source IP belongs to the **security gateway**, not Amazon SES. Since the gateway is not an authorized TurboDocx sender, SPF can show a soft failure:
+
+```
+spf=softfail smtp.mailfrom=e.sign.turbodocx.com sender IP=<security gateway IP>
+```
+
+This does not mean the recipient's domain caused the failure, and **the gateway IP should not be added to TurboDocx's SPF record.**
+
+## How do I confirm it's the recipient's gateway?
+
+1. **Compare against a direct mailbox.** Send the same type of message to Gmail or another mailbox that receives mail directly. A healthy result looks like:
+
+   ```
+   dkim=pass header.d=sign.turbodocx.com
+   dkim=pass header.d=amazonses.com
+   spf=pass
+   dmarc=pass
+   ```
+
+   If it passes when delivered directly but fails only after the recipient's security platform processes it, the downstream platform is the cause.
+
+2. **Read the pre-gateway result.** Look for an `Authentication-Results-Original` header (or similar). If SPF, DKIM, and DMARC passed *before* the gateway processed the message, TurboDocx and SES authenticated correctly.
+
+3. **Temporarily bypass the policy.** Have the recipient's email admin exclude a test mailbox (or the TurboDocx app URL) from URL-rewriting / content-modification, then send a new message with a unique subject. If DKIM and DMARC pass, the policy modification is confirmed as the cause.
+
+## How is it resolved?
+
+**No TurboDocx or Amazon SES change is normally required.** The fix is on the recipient side. Their email administrator can choose to:
+
+- Leave the policy as-is and rely on **ARC** or the platform's trusted-authentication handling. (ARC is designed to preserve original authentication results across an intermediary that modifies the message, though interoperability between platforms can be finicky.)
+- Exclude the TurboDocx application URL from click-time URL rewriting — for Avanan, this typically means excluding `app.turbodocx.com` from link rewriting.
+- Create a narrowly scoped exception for TurboDocx messages.
+- Confirm Microsoft 365 trusts the gateway's ARC seal.
+- Contact the security-platform vendor if messages are being incorrectly quarantined.
+
+Any URL-rewriting exclusion reduces click-time inspection for those links, so the recipient's security administrator should evaluate it.
+
+## What should we *not* do?
+
+- ❌ Add the recipient's gateway IP to TurboDocx's SPF record
+- ❌ Replace working Amazon SES DKIM records
+- ❌ Disable DKIM or DMARC
+- ❌ Exclude an entire organization from email protection without a documented reason
+- ❌ Assume the domain shown in an SPF result is the domain being authenticated
+
+## What information should I collect for escalation?
+
+If you need to escalate, request from the recipient:
+
+- Complete message headers
+- Recipient email platform (e.g. Microsoft 365)
+- Email security product in use (e.g. Avanan)
+- Whether URL rewriting is enabled
+- Whether external banners / disclaimers are inserted
+- Final DKIM, SPF, DMARC, ARC, and composite-authentication results
+- Results of a comparison message sent to Gmail
+- Results of a temporary policy-bypass test
+
+## Bottom line
+
+If TurboDocx messages pass SPF, DKIM, and DMARC when delivered directly but fail after a recipient-side security service modifies the message, the cause is downstream message mutation — not the TurboDocx or Amazon SES configuration. This is especially common in MSP-managed Microsoft 365 environments.

--- a/docs/TurboSign/Email Deliverability and DKIM DMARC.md
+++ b/docs/TurboSign/Email Deliverability and DKIM DMARC.md
@@ -10,20 +10,20 @@ keywords:
   - body hash did not verify
   - avanan
   - email security gateway
-  - amazon ses dkim
+  - dkim signature
   - arc seal
   - safe links
 ---
 
 # Email Deliverability (DKIM / DMARC / SPF)
 
-TurboDocx sends email (including TurboSign signature requests and reminders) through Amazon SES. Occasionally a recipient reports that our messages fail DKIM or DMARC. In nearly every case the cause is a **recipient-side email security gateway that modifies the message after SES has signed it** — not a problem with TurboDocx, SES, or DNS.
+TurboDocx sends email, including TurboSign signature requests and reminders, through an authenticated email delivery service. Occasionally a recipient reports that our messages fail DKIM or DMARC. In nearly every case the cause is a **recipient-side email security gateway that modifies the message after it has been signed** — not a problem with TurboDocx or DNS.
 
 This page explains how to recognize, confirm, and resolve that situation.
 
 ## Why does a TurboDocx email fail DKIM or DMARC?
 
-A DKIM signature includes a cryptographic hash of the message body. Amazon SES signs the email *before* it leaves our infrastructure. If anything downstream changes the signed body, the hash no longer matches and DKIM fails. Because DMARC relies on an aligned SPF **or** DKIM pass, DMARC can fail too.
+A DKIM signature includes a cryptographic hash of the message body. The email is signed *before* it leaves our sending infrastructure. If anything downstream changes the signed body, the hash no longer matches and DKIM fails. Because DMARC relies on an aligned SPF **or** DKIM pass, DMARC can fail too.
 
 Security platforms commonly modify messages in transit by:
 
@@ -44,18 +44,18 @@ A recipient may report any of these:
 - Headers showing `body hash did not verify`
 - SPF passing on first arrival at Microsoft 365 but failing after a relay
 - Message delivers fine to Gmail but fails through Avanan
-- Both the TurboDocx and the Amazon SES DKIM signatures failing at once
+- One or both DKIM signatures on the message failing at once
 
 Typical headers:
 
 ```
 dkim=fail (body hash did not verify) header.d=sign.turbodocx.com
-dkim=fail (body hash did not verify) header.d=amazonses.com
+dkim=fail (body hash did not verify) header.d=<sending provider>
 ```
 
 ## Why does SPF also "softfail" sometimes?
 
-When the gateway relays the message back to Microsoft 365, Microsoft runs SPF again. At that point the source IP belongs to the **security gateway**, not Amazon SES. Since the gateway is not an authorized TurboDocx sender, SPF can show a soft failure:
+When the gateway relays the message back to Microsoft 365, Microsoft runs SPF again. At that point the source IP belongs to the **security gateway**, not the original TurboDocx sender. Since the gateway is not an authorized TurboDocx sender, SPF can show a soft failure:
 
 ```
 spf=softfail smtp.mailfrom=e.sign.turbodocx.com sender IP=<security gateway IP>
@@ -69,20 +69,20 @@ This does not mean the recipient's domain caused the failure, and **the gateway 
 
    ```
    dkim=pass header.d=sign.turbodocx.com
-   dkim=pass header.d=amazonses.com
+   dkim=pass header.d=<sending provider>
    spf=pass
    dmarc=pass
    ```
 
    If it passes when delivered directly but fails only after the recipient's security platform processes it, the downstream platform is the cause.
 
-2. **Read the pre-gateway result.** Look for an `Authentication-Results-Original` header (or similar). If SPF, DKIM, and DMARC passed *before* the gateway processed the message, TurboDocx and SES authenticated correctly.
+2. **Read the pre-gateway result.** Look for an `Authentication-Results-Original` header (or similar). If SPF, DKIM, and DMARC passed *before* the gateway processed the message, TurboDocx authenticated correctly.
 
 3. **Temporarily bypass the policy.** Have the recipient's email admin exclude a test mailbox (or the TurboDocx app URL) from URL-rewriting / content-modification, then send a new message with a unique subject. If DKIM and DMARC pass, the policy modification is confirmed as the cause.
 
 ## How is it resolved?
 
-**No TurboDocx or Amazon SES change is normally required.** The fix is on the recipient side. Their email administrator can choose to:
+**No TurboDocx-side change is normally required.** The fix is on the recipient side. Their email administrator can choose to:
 
 - Leave the policy as-is and rely on **ARC** or the platform's trusted-authentication handling. (ARC is designed to preserve original authentication results across an intermediary that modifies the message, though interoperability between platforms can be finicky.)
 - Exclude the TurboDocx application URL from click-time URL rewriting — for Avanan, this typically means excluding `app.turbodocx.com` from link rewriting.
@@ -95,7 +95,7 @@ Any URL-rewriting exclusion reduces click-time inspection for those links, so th
 ## What should we *not* do?
 
 - ❌ Add the recipient's gateway IP to TurboDocx's SPF record
-- ❌ Replace working Amazon SES DKIM records
+- ❌ Replace working TurboDocx DKIM records
 - ❌ Disable DKIM or DMARC
 - ❌ Exclude an entire organization from email protection without a documented reason
 - ❌ Assume the domain shown in an SPF result is the domain being authenticated
@@ -115,4 +115,4 @@ If you need to escalate, request from the recipient:
 
 ## Bottom line
 
-If TurboDocx messages pass SPF, DKIM, and DMARC when delivered directly but fail after a recipient-side security service modifies the message, the cause is downstream message mutation — not the TurboDocx or Amazon SES configuration. This is especially common in MSP-managed Microsoft 365 environments.
+If TurboDocx messages pass SPF, DKIM, and DMARC when delivered directly but fail after a recipient-side security service modifies the message, the cause is downstream message mutation — not the TurboDocx configuration. This is especially common in MSP-managed Microsoft 365 environments.


### PR DESCRIPTION
## What

Adds a FAQ-styled help page: **TurboSign → Email Deliverability (DKIM / DMARC / SPF)**.

Explains why TurboSign/TurboDocx emails (sent via Amazon SES) can show DKIM, DMARC, or SPF failures when a recipient-side email security gateway — Avanan, Microsoft Safe Links, or similar — rewrites URLs or otherwise modifies the message body *after* SES has signed it, breaking the body hash.

## Why

Sourced from a real customer trace where the failures were caused entirely by downstream message mutation (Avanan URL rewriting) in an MSP-managed Microsoft 365 environment, not by our SES/DNS config. Gives support a ready answer when a similar complaint comes in.

## Contents

- Why DKIM/DMARC fail (body-hash mismatch)
- What the failures look like (symptoms + sample headers)
- Why SPF can softfail after a gateway relay
- How to confirm the cause (direct-mailbox comparison, pre-gateway headers, policy bypass)
- Resolution (recipient-side; no TurboDocx/SES change needed)
- What *not* to do + escalation checklist

Placed under TurboSign (`sidebar_position: 7`) since that's where the SES email originates.