### PR TITLE
ci(docs): fix Generate API docs workflow (submodule + plugin build)

### DIFF
--- a/.github/workflows/generateopenapi.yml
+++ b/.github/workflows/generateopenapi.yml
@@ -13,6 +13,8 @@ jobs:
     steps:
     - name: Checkout repository
       uses: actions/checkout@v4
+      with:
+        submodules: recursive
 
     - name: Set up Node.js
       uses: actions/setup-node@v4
@@ -21,6 +23,9 @@ jobs:
 
     - name: Install dependencies
       run: npm ci
+
+    - name: Build vendored plugins
+      run: npm run prebuild
 
     - name: Generate API docs
       run: npx docusaurus gen-api-docs all


### PR DESCRIPTION
## Problem
The **Generate API docs** workflow has failed on every push to `main` with:

```
[ERROR] Docusaurus was unable to resolve the "docusaurus-plugin-llms" plugin.
```

`docusaurus-plugin-llms` is a git submodule vendored as a `file:` dependency, and its entrypoint `lib/index.js` is compiled (gitignored). The workflow checked out **without submodules** and called `gen-api-docs` directly, **skipping the `prebuild`** that runs `tsc` in the vendor dir. So `docusaurus.config.js` couldn't resolve the plugin.

(`deploy.yml` is unaffected: it does recursive submodule checkout and `npm run build` auto-runs `prebuild`.)

## Fix
Mirror `deploy.yml`:
- `submodules: recursive` on checkout
- `npm run prebuild` step before `gen-api-docs`